### PR TITLE
Added support for proxies in /etc/default/docker config, and downloads

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -20,6 +20,10 @@
     mode: "{{ download.mode|default(omit) }}"
   when: "{{ download.enabled|bool }}"
   run_once: "{{ download_run_once|bool }}"
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ https_proxy }}"
+    no_proxy: "{{ no_proxy }}"
 
 - name: Extract archives
   unarchive:


### PR DESCRIPTION
It would be better to refactor the `network_plugins` so that they are not responsible for setting the `/etc/defaults/docker` file.. they could tweak the `docker_options` .. and next step we would setup Docker..

would that make sense ?
