### PR TITLE
Non-Systemd installs: setup properly proxy variables for Docker

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -75,6 +75,15 @@
   notify: restart docker
   when: ansible_service_mgr == "systemd" and ansible_os_family != "CoreOS"
 
+- name: Set docker proxy variables for non-systemd installs
+  template:
+    src: docker.j2
+    dest: /etc/default/docker
+  notify: restart docker
+  when: ansible_service_mgr in ["sysvinit","upstart"] and
+        ansible_os_family == "Debian" and
+        (http_proxy is defined or https_proxy is defined or no_proxy is defined)
+
 - meta: flush_handlers
 
 - name: ensure docker service is started and enabled

--- a/roles/docker/templates/docker.j2
+++ b/roles/docker/templates/docker.j2
@@ -1,0 +1,18 @@
+# Deployed by Ansible
+{% if (ansible_service_mgr in ["sysvinit","upstart"] and ansible_os_family == "Debian") %}
+DOCKER_OPTS="{% if docker_options is defined %}{{ docker_options }}{% endif %}"
+{% else %}
+OPTIONS="{% if docker_options is defined %}{{ docker_options }}{% endif %}"
+{% endif %}
+
+{% if (ansible_service_mgr in ["sysvinit","upstart"] and ansible_os_family == "Debian") %}
+{% if http_proxy %}
+export HTTP_PROXY="{{ http_proxy }}"
+{% endif %}
+{% if https_proxy %}
+export HTTPS_PROXY="{{ https_proxy }}"
+{% endif %}
+{% if no_proxy %}
+export NO_PROXY="{{ no_proxy }}"
+{% endif %}
+{% endif %}

--- a/roles/network_plugin/flannel/templates/docker
+++ b/roles/network_plugin/flannel/templates/docker
@@ -4,3 +4,15 @@ DOCKER_OPTS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }} {% if docker_opt
 {% else %}
 OPTIONS="--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }} {% if docker_options is defined %}{{ docker_options }}{% endif %}"
 {% endif %}
+
+{% if (ansible_service_mgr in ["sysvinit","upstart"] and ansible_os_family == "Debian") %}
+{% if http_proxy %}
+export HTTP_PROXY="{{ http_proxy }}"
+{% endif %}
+{% if https_proxy %}
+export HTTPS_PROXY="{{ https_proxy }}"
+{% endif %}
+{% if no_proxy %}
+export NO_PROXY="{{ no_proxy }}"
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Without that, docker will not be able to fetch external images in non-systemd setups.
