### PR TITLE
Fix idempotency of calico-policy-controller rs

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/calico-policy-controller.yml
+++ b/roles/kubernetes-apps/ansible/tasks/calico-policy-controller.yml
@@ -5,6 +5,9 @@
 
 - name: Start of Calico policy controller
   kube:
+    name: "calico-policy-controller"
     kubectl: "{{bin_dir}}/kubectl"
-    filename: /etc/kubernetes/calico-policy-controller.yml
+    filename: "/etc/kubernetes/calico-policy-controller.yml"
+    namespace: "kube-system"
+    resource: "rs"
   when: inventory_hostname == groups['kube-master'][0]


### PR DESCRIPTION
We need to specify kube resource type and name in order to avoid
playbook errors related to k8s resource duplication.