### PR TITLE
Fix policy controller

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -10,3 +10,6 @@ kubednsmasq_image_repo: "gcr.io/google_containers/kube-dnsmasq-amd64"
 kubednsmasq_image_tag: "{{ kubednsmasq_version }}"
 exechealthz_image_repo: "gcr.io/google_containers/exechealthz-amd64"
 exechealthz_image_tag: "{{ exechealthz_version }}"
+
+# SSL
+etcd_cert_dir: "/etc/ssl/etcd/ssl"

--- a/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
@@ -44,12 +44,11 @@ spec:
             # This removes the need for KubeDNS to resolve the Service.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
-    volumeMounts:
-    - mountPath: {{ etcd_cert_dir }}
-      name: etcd-certs
-      readOnly: true
-  volumes:
-  - hostPath:
-      path: {{ etcd_cert_dir }}
-    name: etcd-certs
-
+          volumeMounts:
+          - mountPath: {{ etcd_cert_dir }}
+            name: etcd-certs
+            readOnly: true
+      volumes:
+      - hostPath:
+          path: {{ etcd_cert_dir }}
+        name: etcd-certs


### PR DESCRIPTION
'etcd_cert_dir' variable is missing from 'kubernetes-apps/ansible'
role which breaks Calico policy controller deployment.

Also fixing calico-policy-controller.yml.