### PR TITLE
Adds missing 'ip' var for terraform-generated inventory, based on internal ip

### DIFF
--- a/contrib/terraform/terraform.py
+++ b/contrib/terraform/terraform.py
@@ -309,6 +309,7 @@ def openstack_host(resource, module_name):
     attrs = {
         'access_ip_v4': raw_attrs['access_ip_v4'],
         'access_ip_v6': raw_attrs['access_ip_v6'],
+        'ip': raw_attrs['network.0.fixed_ip_v4'],
         'flavor': parse_dict(raw_attrs, 'flavor',
                              sep='_'),
         'id': raw_attrs['id'],


### PR DESCRIPTION
This PR sorts out problems found in #578 . As 'ip' was not defined in the terraform-based dynamically generated ansible inventory, an incorrect default was being used by ansible. As a result of this, etcd was being configured with wrong set of IPs.