### PR TITLE
Replace calico-cni binaries with calico/cni container

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -19,13 +19,9 @@ pod_infra_version: 3.0
 
 # Download URL's
 etcd_download_url: "https://storage.googleapis.com/kargo/{{etcd_version}}_etcd"
-calico_cni_download_url: "https://storage.googleapis.com/kargo/{{calico_cni_version}}_calico-cni-plugin"
-calico_cni_ipam_download_url: "https://storage.googleapis.com/kargo/{{calico_cni_version}}_calico-cni-plugin-ipam"
 weave_download_url: "https://storage.googleapis.com/kargo/{{weave_version}}_weave"
 
 # Checksums
-calico_cni_checksum: "9cab29764681e9d80da826e4b2cd10841cc01a749e0018867d96dd76a4691548"
-calico_cni_ipam_checksum: "09d076b15b791956efee91646e47fdfdcf382db16082cef4f542a9fff7bae172"
 weave_checksum: "9bf9d6e5a839e7bcbb28cc00c7acae9d09284faa3e7a3720ca9c2b9e93c68580"
 etcd_checksum: "385afd518f93e3005510b7aaa04d38ee4a39f06f5152cd33bb86d4f0c94c7485"
 
@@ -52,24 +48,6 @@ pod_infra_image_repo: "gcr.io/google_containers/pause-amd64"
 pod_infra_image_tag: "{{ pod_infra_version }}"
 
 downloads:
-  calico_cni_plugin:
-    dest: calico/bin/calico
-    version: "{{calico_cni_version}}"
-    sha256: "{{ calico_cni_checksum }}"
-    source_url: "{{ calico_cni_download_url }}"
-    url: "{{ calico_cni_download_url }}"
-    owner: "root"
-    mode: "0755"
-    enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
-  calico_cni_plugin_ipam:
-    dest: calico/bin/calico-ipam
-    version: "{{calico_cni_version}}"
-    sha256: "{{ calico_cni_ipam_checksum }}"
-    source_url: "{{ calico_cni_ipam_download_url }}"
-    url: "{{ calico_cni_ipam_download_url }}"
-    owner: "root"
-    mode: "0755"
-    enabled: "{{ kube_network_plugin == 'calico' }}"
   weave:
     dest: weave/bin/weave
     version: "{{weave_version}}"
@@ -119,7 +97,7 @@ downloads:
     container: true
     repo: "{{ calico_cni_image_repo }}"
     tag: "{{ calico_cni_image_tag }}"
-    enabled: "{{ kube_network_plugin == 'canal' }}"
+    enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
   pod_infra:
     container: true
     repo: "{{ pod_infra_image_repo }}"

--- a/roles/network_plugin/calico/meta/main.yml
+++ b/roles/network_plugin/calico/meta/main.yml
@@ -1,9 +1,7 @@
 ---
 dependencies:
   - role: download
-    file: "{{ downloads.calico_cni_plugin }}"
-  - role: download
-    file: "{{ downloads.calico_cni_plugin_ipam }}"
+    file: "{{ downloads.calico_cni }}"
   - role: download
     file: "{{ downloads.calico_node }}"
   - role: download

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -48,13 +48,12 @@
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
 
-- name: Calico | Install calico cni bin
-  command: rsync -pi "{{ local_release_dir }}/calico/bin/calico" "/opt/cni/bin/calico"
-  changed_when: false
-  when: "{{ overwrite_hyperkube_cni|bool }}"
-
-- name: Calico | Install calico-ipam cni bin
-  command: rsync -pi "{{ local_release_dir }}/calico/bin/calico-ipam" "/opt/cni/bin/calico-ipam"
+- name: Calico | Copy cni plugins from calico/cni container
+  command: "/usr/bin/docker run --rm -v /opt/cni/bin:/cnibindir {{ calico_cni_image_repo }}:{{ calico_cni_image_tag }} sh -c 'cp -a /opt/cni/bin/* /cnibindir/'"
+  register: cni_task_result
+  until: cni_task_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
   when: "{{ overwrite_hyperkube_cni|bool }}"
 


### PR DESCRIPTION
Calico CNI binaries are also released/shipped in calico/cni
container. This patch adds support for using this container as a
source of Calico CNI binaries.