### PR TITLE
Move CNI config and add MTU support for calico-cni

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -4,13 +4,6 @@
 - include: nginx-proxy.yml
   when: is_kube_master == false and loadbalancer_apiserver_localhost|default(false)
 
-- name: Write Calico cni config
-  template:
-    src: "cni-calico.conf.j2"
-    dest: "/etc/cni/net.d/10-calico.conf"
-    owner: kube
-  when: kube_network_plugin == "calico"
-
 - name: Write kubelet config file
   template: src=kubelet.j2 dest={{ kube_config_dir }}/kubelet.env backup=yes
   notify:

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -11,3 +11,8 @@ overwrite_hyperkube_cni: true
 
 calico_cert_dir: /etc/calico/certs
 etcd_cert_dir: /etc/ssl/etcd/ssl
+
+# You can set MTU value here. If left undefined or empty, it will
+# not be specified in calico CNI config, so Calico will use built-in
+# defaults. The value should be a number, not a string.
+# calico_mtu: 1500

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Calico | Write Calico cni config
+  template:
+    src: "cni-calico.conf.j2"
+    dest: "/etc/cni/net.d/10-calico.conf"
+    owner: kube
+
 - name: Calico | Set docker daemon options
   template:
     src: docker

--- a/roles/network_plugin/calico/templates/cni-calico.conf.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conf.j2
@@ -14,6 +14,9 @@
     "type": "k8s"
   },
 {% endif %}
+{% if calico_mtu is defined and calico_mtu is number %}
+  "mtu": {{ calico_mtu }},
+{% endif %}
   "kubernetes": {
     "kubeconfig": "{{ kube_config_dir }}/node-kubeconfig.yaml"
   }


### PR DESCRIPTION
- Move CNI configuration creation for Calico to appropriate
network_plugin role from kubernetes/node.
- Add support for MTU configuration in Calico.