### PR TITLE
Fix mountflags and kubelet config

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -21,7 +21,7 @@ KUBELET_ARGS="--cluster_dns={{ skydns_server }} --cluster_domain={{ dns_domain }
 {% elif dns_setup|bool %}
 KUBELET_ARGS="--cluster_dns={{ dns_server }} --cluster_domain={{ dns_domain }} --kubeconfig={{ kube_config_dir}}/node-kubeconfig.yaml --require-kubeconfig --pod-manifest-path={{ kube_manifest_dir }} --resolv-conf={{ kube_resolv_conf }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"
 {% else %}
-KUBELET_ARGS="--kubeconfig={{ kube_config_dir}}/kubelet.kubeconfig --pod-manifest-path={{ kube_manifest_dir }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"
+KUBELET_ARGS="--kubeconfig={{ kube_config_dir}}/kubelet.kubeconfig --require-kubeconfig --pod-manifest-path={{ kube_manifest_dir }} --pod-infra-container-image={{ pod_infra_image_repo }}:{{ pod_infra_image_tag }}"
 {% endif %}
 {% if kube_network_plugin is defined and kube_network_plugin in ["calico", "weave", "canal"] %}
 KUBELET_NETWORK_PLUGIN="--network-plugin=cni --network-plugin-dir=/etc/cni/net.d"

--- a/roles/network_plugin/canal/templates/canal-node.yml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yml.j2
@@ -111,6 +111,7 @@ spec:
               mountPath: "/run/flannel"
             - name: "canal-certs"
               mountPath: "{{ canal_cert_dir }}"
+              readOnly: true
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and local routes on each
         # host.
@@ -156,3 +157,4 @@ spec:
               readOnly: false
             - name: "canal-certs"
               mountPath: "{{ canal_cert_dir }}"
+              readOnly: true

--- a/roles/network_plugin/flannel/templates/flannel-pod.yml
+++ b/roles/network_plugin/flannel/templates/flannel-pod.yml
@@ -33,6 +33,7 @@
             mountPath: "/run/flannel"
           - name: "etcd-certs"
             mountPath: "{{ etcd_cert_dir }}"
+            readOnly: true
         securityContext:
           privileged: true
     hostNetwork: true


### PR DESCRIPTION
Add missing --require-kubeconfig to the if..else stanza.
Make sure certs dirs mounted in RO.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>