### PR TITLE
Fix failure if image package index is outdated

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -7,7 +7,7 @@
   ignore_errors: True
 
 - name: Bootstrap | Install python 2.x
-  raw: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y python-minimal
+  raw: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal
   when: need_bootstrap | failed
 
 - set_fact:

--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -7,7 +7,7 @@
   ignore_errors: True
 
 - name: Bootstrap | Install python 2.x
-  raw: DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal
+  raw: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y python-minimal
   when: need_bootstrap | failed
 
 - set_fact:


### PR DESCRIPTION
We failed to lift a kubernetes cluster, because the available Ubuntu image
on the nodes had outdated package indexes, and python-minimal was not installed.
This is fixed by running apt-get update before the apt-get install python-minimal.
Yours, Steffen