### PR TITLE
Fix sugested bootstrap options

### DIFF
--- a/contrib/terraform/openstack/group_vars/all.yml
+++ b/contrib/terraform/openstack/group_vars/all.yml
@@ -1,4 +1,4 @@
-# Valid bootstrap options (required): xenial, coreos, none
+# Valid bootstrap options (required): ubuntu, coreos, none
 bootstrap_os: "none" 
 
 # Directory where the binaries will be installed


### PR DESCRIPTION
"xenial" was not a valid choice and failed, changed the comment suggesting this 
to now be in sync with https://github.com/kubernetes-incubator/kargo/blob/master/inventory/group_vars/all.yml 
Yours, Steffen
