### PR TITLE
Fix download_run_once for containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ cache:
   - directories:
     - $HOME/.cache/pip
     - $HOME/.local
+    - /var/tmp/releases
 
 before_script:
   - echo "RUN $TRAVIS_JOB_NUMBER $KUBE_NETWORK_PLUGIN $CONTAINER_ENGINE "
@@ -151,6 +152,8 @@ script:
     -b --become-user=root -e cloud_provider=gce  $LOG_LEVEL -e kube_network_plugin=${KUBE_NETWORK_PLUGIN}
     -e bootstrap_os=${BOOTSTRAP_OS}
     -e ansible_python_interpreter=${PYPATH}
+    -e download_run_once=true
+    -e local_release_dir=/var/tmp/releases
     cluster.yml
 
     # Tests Cases

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -44,7 +44,7 @@
   when: "{{ download.enabled|bool and download.container|bool }}"
 
 - name: Create dest directory for saved/loaded container images
-  file: path="{{local_release_dir}}/containers" state=directory recurse=yes
+  file: path="{{local_release_dir}}/containers" state=directory recurse=yes mode=0755 owner="{{ansible_ssh_user}}"
   when: "{{ download.enabled|bool and download.container|bool }}"
 
 #NOTE(bogdando) this brings no docker-py deps for nodes
@@ -78,11 +78,29 @@
   run_once: true
   when: ansible_os_family != "CoreOS" and download_run_once|bool and download.enabled|bool and download.container|bool and container_changed|bool
 
-- name: Download | get container images
+- name: Download | create local directory for saved/loaded container images
+  file: path="{{local_release_dir}}/containers" state=directory recurse=yes mode=0755
+  delegate_to: localhost
+  become: false
+  run_once: true
+  when: "{{ download.enabled|bool and download.container|bool }}"
+
+- name: Download | copy container images to ansible host
   synchronize:
     src: "{{ fname }}"
-    dest: "{{local_release_dir}}/containers"
+    dest: "{{ fname }}"
+    mode: pull
+  delegate_to: localhost
+  become: false
+  when: ansible_os_family != "CoreOS" and inventory_hostname == groups['kube-master'][0] and download_run_once|bool and download.enabled|bool and download.container|bool
+
+- name: Download | upload container images to nodes
+  synchronize:
+    src: "{{ fname }}"
+    dest: "{{ fname }}"
     mode: push
+  delegate_to: localhost
+  become: false
   register: get_task
   until: get_task|success
   retries: 4


### PR DESCRIPTION
Add one more step (task) to containers download/upload sequence -
copy saved .tar containers to ansible host (delegate_to: localhost).

Then upload images to target nodes. It uses synchronize module so
if ansible host (localhost) is the same host as kube-master[0] then
new task causes no issues and the copy to localhost process is
basically skipped.

Closes #612