### PR TITLE
Add ability to define network backend for Calico.

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -50,6 +50,16 @@ or for versions prior *v1.0.0*:
 calicoctl endpoint show --detail
 ```
 
+##### Optionnal : Define network backend
+
+In some cases you may want to define Calico network backend. Allowed values are 'bird', 'gobgp' or 'none'. Bird is a default value.
+
+To re-define you need to edit the inventory and add a group variable `calico_network_backend`
+
+```
+calico_network_backend: none
+```
+
 ##### Optionnal : BGP Peering with border routers
 
 In some cases you may want to route the pods subnet and so NAT is not needed on the nodes.

--- a/roles/network_plugin/calico/templates/calico-node.service.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.j2
@@ -15,9 +15,9 @@ ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.
 {% endif %}
 {% else %}
 {% if inventory_hostname in groups['kube-node'] and peer_with_router|default(false)%}
-ExecStart={{ bin_dir }}/calicoctl node run --ip={{ip | default(ansible_default_ipv4.address) }} --as={{ local_as }} --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
+ExecStart={{ bin_dir }}/calicoctl node run --ip={{ip | default(ansible_default_ipv4.address) }} --as={{ local_as }} --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }} {% if calico_network_backend is defined %}--backend={{calico_network_backend }}{% endif %}
 {%     else %}
-ExecStart={{ bin_dir }}/calicoctl node run --ip={{ip | default(ansible_default_ipv4.address) }} --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
+ExecStart={{ bin_dir }}/calicoctl node run --ip={{ip | default(ansible_default_ipv4.address) }} --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }} {% if calico_network_backend is defined %}--backend={{calico_network_backend }}{% endif %}
 {% endif %}
 {% endif %}
 Restart=always


### PR DESCRIPTION
This PR introduce `calico_network_backend` global variable,
which allow to describe alternative network backend.
Default behavior is unchanged.

Allowed values are 'bird', 'gobgp' or 'none',  'bird' is a default value.