### PR TITLE
Install python 2.7 on Ubuntu Xenial

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -5,7 +5,10 @@
     - bootstrap-os
   tags:
     - bootstrap-os
-
+  tasks:
+    - name: install python 2
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'xenial'
 
 - hosts: all
   gather_facts: true


### PR DESCRIPTION
The base image of Ubuntu Xenial does not
come with Python pre-installed, this results
in ansible failing until it is installed.

This patch adds code to ensure that ansible
installs it as a dependency.