### PR TITLE
Ensure that etcd health checks always pass

### DIFF
--- a/roles/etcd/handlers/main.yml
+++ b/roles/etcd/handlers/main.yml
@@ -10,18 +10,18 @@
   command: systemctl daemon-reload
   when: ansible_service_mgr == "systemd"
 
+- name: reload etcd
+  service:
+    name: etcd
+    state: restarted
+  when: is_etcd_master
+
 - name: wait for etcd up
   uri: url="https://{% if is_etcd_master %}{{ etcd_address }}{% else %}127.0.0.1{% endif %}:2379/health" validate_certs=no
   register: result
   until: result.status is defined and result.status == 200
   retries: 10
   delay: 5
-
-- name: reload etcd
-  service:
-    name: etcd
-    state: restarted
-  when: is_etcd_master
 
 - name: set etcd_secret_changed
   set_fact:


### PR DESCRIPTION
in the etcd handler, the reload etcd action
was called after ansible waits for etcd to be
up, this means that the health checks which are
called immediately after fail (resulting in the etcd
role always failing and never finishing)

This patch changes the order to move the 'wait for etcd
up' resource after the 'reload etcd resource', ensuring that
the service is up before the health check is called.