### PR TITLE
Download images as dependencies of roles

### DIFF
--- a/roles/dnsmasq/meta/main.yml
+++ b/roles/dnsmasq/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - role: download
+    file: "{{ downloads.dnsmasq }}"
+    when: not skip_dnsmasq|default(false)

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -24,7 +24,6 @@ calico_version: v1.0.0-beta
 calico_cni_version: v1.4.2
 weave_version: v1.6.1
 flannel_version: v0.6.2
-flannel_server_helper_version: 0.1
 pod_infra_version: 3.0
 
 # Download URL's
@@ -40,8 +39,6 @@ etcd_checksum: "385afd518f93e3005510b7aaa04d38ee4a39f06f5152cd33bb86d4f0c94c7485
 etcd_deployment_type: "docker"
 etcd_image_repo: "quay.io/coreos/etcd"
 etcd_image_tag: "{{ etcd_version }}"
-flannel_server_helper_image_repo: "gcr.io/google_containers/flannel-server-helper"
-flannel_server_helper_image_tag: "{{ flannel_server_helper_version }}"
 flannel_image_repo: "quay.io/coreos/flannel"
 flannel_image_tag: "{{ flannel_version }}"
 calicoctl_image_repo: "calico/ctl"
@@ -52,10 +49,28 @@ calico_node_image_repo: "calico/node"
 calico_node_image_tag: "{{ calico_version }}"
 calico_cni_image_repo: "calico/cni"
 calico_cni_image_tag: "{{ calico_cni_version }}"
+calico_policy_image_repo: "calico/kube-policy-controller"
+calico_policy_image_tag: latest
+exechealthz_version: 1.1
+exechealthz_image_repo: "gcr.io/google_containers/exechealthz-amd64"
+exechealthz_image_tag: "{{ exechealthz_version }}"
 hyperkube_image_repo: "quay.io/coreos/hyperkube"
 hyperkube_image_tag: "{{ kube_version }}_coreos.0"
 pod_infra_image_repo: "gcr.io/google_containers/pause-amd64"
 pod_infra_image_tag: "{{ pod_infra_version }}"
+nginx_image_repo: nginx
+nginx_image_tag: 1.11.4-alpine
+dnsmasq_version: 2.72
+dnsmasq_image_repo: "andyshinn/dnsmasq"
+dnsmasq_image_tag: "{{ dnsmasq_version }}"
+kubednsmasq_version: 1.3
+kubednsmasq_image_repo: "gcr.io/google_containers/kube-dnsmasq-amd64"
+kubednsmasq_image_tag: "{{ kubednsmasq_version }}"
+kubedns_version: 1.7
+kubedns_image_repo: "gcr.io/google_containers/kubedns-amd64"
+kubedns_image_tag: "{{ kubedns_version }}"
+test_image_repo: busybox
+test_image_tag: latest
 
 downloads:
   weave:
@@ -88,11 +103,6 @@ downloads:
     repo: "{{ flannel_image_repo }}"
     tag: "{{ flannel_image_tag }}"
     enabled: "{{ kube_network_plugin == 'flannel' or kube_network_plugin == 'canal' }}"
-  flannel_server_helper:
-    container: true
-    repo: "{{ flannel_server_helper_image_repo }}"
-    tag: "{{ flannel_server_helper_image_tag }}"
-    enabled: "{{ kube_network_plugin == 'flannel' or kube_network_plugin == 'canal' }}"
   calicoctl:
     container: true
     repo: "{{ calicoctl_image_repo }}"
@@ -108,10 +118,39 @@ downloads:
     repo: "{{ calico_cni_image_repo }}"
     tag: "{{ calico_cni_image_tag }}"
     enabled: "{{ kube_network_plugin == 'calico' or kube_network_plugin == 'canal' }}"
+  calico_policy:
+    container: true
+    repo: "{{ calico_policy_image_repo }}"
+    tag: "{{ calico_policy_image_tag }}"
+    enabled: "{{ kube_network_plugin == 'canal' }}"
   pod_infra:
     container: true
     repo: "{{ pod_infra_image_repo }}"
     tag: "{{ pod_infra_image_tag }}"
+  nginx:
+    container: true
+    repo: "{{ nginx_image_repo }}"
+    tag: "{{ nginx_image_tag }}"
+  dnsmasq:
+    container: true
+    repo: "{{ dnsmasq_image_repo }}"
+    tag: "{{ dnsmasq_image_tag }}"
+  kubednsmasq:
+    container: true
+    repo: "{{ kubednsmasq_image_repo }}"
+    tag: "{{ kubednsmasq_image_tag }}"
+  kubedns:
+    container: true
+    repo: "{{ kubedns_image_repo }}"
+    tag: "{{ kubedns_image_tag }}"
+  testbox:
+    container: true
+    repo: "{{ test_image_repo }}"
+    tag: "{{ test_image_tag }}"
+  exechealthz:
+    container: true
+    repo: "{{ exechealthz_image_repo }}"
+    tag: "{{ exechealthz_image_tag }}"
 
 download:
   container: "{{ file.container|default('false') }}"

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -10,6 +10,8 @@ kubednsmasq_image_repo: "gcr.io/google_containers/kube-dnsmasq-amd64"
 kubednsmasq_image_tag: "{{ kubednsmasq_version }}"
 exechealthz_image_repo: "gcr.io/google_containers/exechealthz-amd64"
 exechealthz_image_tag: "{{ exechealthz_version }}"
+calico_policy_image_repo: "calico/kube-policy-controller"
+calico_policy_image_tag: latest
 
 # SSL
 etcd_cert_dir: "/etc/ssl/etcd/ssl"

--- a/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: calico/kube-policy-controller:latest
+          image: {{ calico_policy_image_repo }}:{{ calico_policy_image_tag }}
           env:
             - name: ETCD_ENDPOINTS
               value: "{{ etcd_access_endpoint }}"

--- a/roles/kubernetes/node/meta/main.yml
+++ b/roles/kubernetes/node/meta/main.yml
@@ -5,3 +5,17 @@ dependencies:
   - role: download
     file: "{{ downloads.pod_infra }}"
   - role: kubernetes/secrets
+  - role: download
+    file: "{{ downloads.nginx }}"
+    when: is_kube_master == false and loadbalancer_apiserver_localhost|default(false)
+  - role: download
+    file: "{{ downloads.testbox }}"
+  - role: download
+    file: "{{ downloads.kubednsmasq }}"
+    when: not skip_dnsmasq_k8s|default(false)
+  - role: download
+    file: "{{ downloads.kubedns }}"
+    when: not skip_dnsmasq_k8s|default(false)
+  - role: download
+    file: "{{ downloads.exechealthz }}"
+    when: not skip_dnsmasq_k8s|default(false)

--- a/roles/network_plugin/canal/meta/main.yml
+++ b/roles/network_plugin/canal/meta/main.yml
@@ -1,8 +1,6 @@
 ---
 dependencies:
   - role: download
-    file: "{{ downloads.flannel_server_helper }}"
-  - role: download
     file: "{{ downloads.flannel }}"
   - role: download
     file: "{{ downloads.calico_node }}"
@@ -10,3 +8,5 @@ dependencies:
     file: "{{ downloads.calicoctl }}"
   - role: download
     file: "{{ downloads.calico_cni }}"
+  - role: download
+    file: "{{ downloads.calico_policy }}"

--- a/roles/network_plugin/flannel/meta/main.yml
+++ b/roles/network_plugin/flannel/meta/main.yml
@@ -1,6 +1,4 @@
 ---
 dependencies:
   - role: download
-    file: "{{ downloads.flannel_server_helper }}"
-  - role: download
     file: "{{ downloads.flannel }}"

--- a/scripts/collect-info.yaml
+++ b/scripts/collect-info.yaml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
-  become: false
+  become: true
   gather_facts: no
 
   vars:
@@ -24,11 +24,13 @@
       - name: errors_info
         cmd: journalctl -p err --no-pager
       - name: etcd_info
-        cmd: etcdctl --debug cluster-health
+        cmd: etcdctl --peers={{ etcd_access_addresses }} cluster-health
       - name: weave_info
-        cmd: weave report | jq "."
+        cmd: weave report
       - name: weave_logs
         cmd: docker logs weave
+      - name: kube_describe_all
+        cmd: kubectl describe all --all-namespaces
       - name: kubedns_logs
         cmd: "for i in `kubectl get pods --all-namespaces -l k8s-app=kubedns -o jsonpath={.items..metadata.name}`;
           do kubectl logs ${i} --namespace kube-system kubedns; done"
@@ -70,6 +72,12 @@
       - /var/log/calico/confd/current
 
   tasks:
+    - set_fact:
+        etcd_access_addresses: |-
+          {% for item in groups['etcd'] -%}
+            https://{{ item }}:2379{% if not loop.last %},{% endif %}
+          {%- endfor %}
+
     - name: Storing commands output
       shell: "{{ item.cmd }} 2>&1 | tee {{ item.name }}"
       register: output

--- a/tests/testcases/020_check-create-pod.yml
+++ b/tests/testcases/020_check-create-pod.yml
@@ -1,6 +1,10 @@
 ---
 - hosts: node1
 
+  vars:
+    test_image_repo: busybox
+    test_image_tag: latest
+
   tasks:
 
   - name: Force binaries directory for CoreOS
@@ -13,7 +17,7 @@
     when: ansible_os_family != "CoreOS"
 
   - name: Run a replica controller composed of 2 pods
-    shell: "{{bin_dir}}/kubectl run test --image=busybox --replicas=2 --command -- tail -f /dev/null"
+    shell: "{{bin_dir}}/kubectl run test --image={{test_image_repo}}:{{test_image_tag}} --replicas=2 --command -- tail -f /dev/null"
 
   - name: Pods are running
     shell: "{{bin_dir}}/kubectl get pods --no-headers -o json"


### PR DESCRIPTION
Pre download all required container images as roles' deps.
Drop unused flannel-server-helper images pre download.
Improve pods creation post-install test pre downloaded busybox.
Improve logs collection script with kubectl describe, fix sudo/etcd/weave
commands.

Closes https://github.com/kubernetes-incubator/kargo/issues/634

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>