### PR TITLE
Add missing liveness probe for apiserver static pod

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -48,7 +48,13 @@ spec:
 {% elif cloud_provider is defined and cloud_provider == "aws" %}
     - --cloud-provider={{ cloud_provider }}
 {% endif %}
-    - 2>&1 >> {{ kube_log_dir }}/kube-apiserver.log
+    livenessProbe:
+      httpGet:
+        host: 127.0.0.1
+        path: /healthz
+        port: 8080
+      initialDelaySeconds: 30
+      timeoutSeconds: 10
     volumeMounts:
     - mountPath: {{ kube_config_dir }}
       name: kubernetes-config
@@ -59,8 +65,6 @@ spec:
     - mountPath: {{ etcd_cert_dir }}
       name: etcd-certs
       readOnly: true
-    - mountPath: /var/log/
-      name: logfile
   volumes:
   - hostPath:
       path: {{ kube_config_dir }}
@@ -71,6 +75,3 @@ spec:
   - hostPath:
       path: {{ etcd_cert_dir }}
     name: etcd-certs
-  - hostPath:
-      path: /var/log/
-    name: logfile


### PR DESCRIPTION
Fix unreliable waiting for the apiserver to become ready.
Remove logfile mount to align with the rest of static pods
and because containers shall write logs to stdout only.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>