### PR TITLE
Increase wait for pods post-install test

### DIFF
--- a/tests/testcases/020_check-create-pod.yml
+++ b/tests/testcases/020_check-create-pod.yml
@@ -19,5 +19,5 @@
     shell: "{{bin_dir}}/kubectl get pods --no-headers -o json"
     register: run_pods_log
     until: [ '(run_pods_log.stdout | from_json)["items"] | map(attribute = "status.phase") | join(",") == "Running,Running"' ]
-    retries: 24
-    delay: 5
+    retries: 18
+    delay: 10


### PR DESCRIPTION
The test deployment/rc/pods creation time
is near 2m on slow CI instances with 1 CPU/1.7G RAM.
Increase wait time to allow the post test fail less often.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>