### PR TITLE
Fix conditional when setting loadbalancer_apiserver_localhost

### DIFF
--- a/roles/kubernetes/preinstall/tasks/set_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_facts.yml
@@ -6,7 +6,7 @@
 - set_fact: first_kube_master="{{ hostvars[groups['kube-master'][0]]['access_ip'] | default(hostvars[groups['kube-master'][0]]['ip'] | default(hostvars[groups['kube-master'][0]]['ansible_default_ipv4']['address'])) }}"
 - set_fact:
     loadbalancer_apiserver_localhost: false
-    when: loadbalancer_apiserver is defined
+  when: loadbalancer_apiserver is defined
 - set_fact:
     kube_apiserver_endpoint: |-
       {% if not is_kube_master and loadbalancer_apiserver_localhost -%}


### PR DESCRIPTION
Wrong indentation caused loadbalancer_apiserver_localhost to be always set to false