### PR TITLE
Decouple etcd/k8s-cluster roles in ec2 terraform

### DIFF
--- a/contrib/terraform/aws/01-create-inventory.tf
+++ b/contrib/terraform/aws/01-create-inventory.tf
@@ -32,6 +32,6 @@ resource "null_resource" "ansible-provision" {
   }
 
   provisioner "local-exec" {
-    command =  "echo \"\n[k8s-cluster:children]\nkube-node\nkube-master\netcd\" >> inventory"
+    command =  "echo \"\n[k8s-cluster:children]\nkube-node\nkube-master\" >> inventory"
   }
 }


### PR DESCRIPTION
Currently, the terraform script in contrib
adds etcd role as a child of k8s-cluster in
its generated inventory file.

This is problematic when the etcd role is
deployed on separate nodes from the k8s master
and nodes. In this case, this leads to failures
of the k8s node since the PKI certs required for
that role have not been propogated.