### PR TITLE
Allow pre-downloaded images to be used effectively

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -139,6 +139,9 @@ dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address')
 ## to self hosted registries like so:
 docker_options: "--insecure-registry={{ kube_service_addresses }}"
 
+# K8s image pull policy (imagePullPolicy)
+k8s_image_pull_policy: IfNotPresent
+
 # default packages to install within the cluster
 kpm_packages: []
 #  - name: kube-system/grafana

--- a/roles/dnsmasq/templates/dnsmasq-ds.yml
+++ b/roles/dnsmasq/templates/dnsmasq-ds.yml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: dnsmasq
           image: "{{ dnsmasq_image_repo }}:{{ dnsmasq_image_tag }}"
+          imagePullPolicy: {{ k8s_image_pull_policy }}
           command:
             - dnsmasq
           args:

--- a/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
@@ -24,6 +24,7 @@ spec:
       containers:
         - name: calico-policy-controller
           image: {{ calico_policy_image_repo }}:{{ calico_policy_image_tag }}
+          imagePullPolicy: {{ k8s_image_pull_policy }}
           env:
             - name: ETCD_ENDPOINTS
               value: "{{ etcd_access_endpoint }}"

--- a/roles/kubernetes-apps/ansible/templates/kubedns-rc.yml
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-rc.yml
@@ -22,6 +22,7 @@ spec:
       containers:
       - name: kubedns
         image: "{{ kubedns_image_repo }}:{{ kubedns_image_tag }}"
+        imagePullPolicy: {{ k8s_image_pull_policy }}
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -64,6 +65,7 @@ spec:
           protocol: TCP
       - name: dnsmasq
         image: "{{ kubednsmasq_image_repo }}:{{ kubednsmasq_image_tag }}"
+        imagePullPolicy: {{ k8s_image_pull_policy }}
         args:
         - --log-facility=-
         - --cache-size=1000
@@ -78,6 +80,7 @@ spec:
           protocol: TCP
       - name: healthz
         image: "{{ exechealthz_image_repo }}:{{ exechealthz_image_tag }}"
+        imagePullPolicy: {{ k8s_image_pull_policy }}
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -10,6 +10,7 @@ spec:
   containers:
   - name: kube-apiserver
     image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
     command:
     - /hyperkube
     - apiserver

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -10,6 +10,7 @@ spec:
   containers:
   - name: kube-controller-manager
     image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
     command:
     - /hyperkube
     - controller-manager

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -10,6 +10,7 @@ spec:
   containers:
   - name: kube-scheduler
     image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
     command:
     - /hyperkube
     - scheduler

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -10,6 +10,7 @@ spec:
   containers:
   - name: kube-proxy
     image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
     command:
     - /hyperkube
     - proxy

--- a/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/nginx-proxy.manifest.j2
@@ -10,6 +10,7 @@ spec:
   containers:
   - name: nginx-proxy
     image: {{ nginx_image_repo }}:{{ nginx_image_tag }}
+    imagePullPolicy: {{ k8s_image_pull_policy }}
     securityContext:
       privileged: true
     volumeMounts:

--- a/roles/network_plugin/canal/templates/canal-node.yml.j2
+++ b/roles/network_plugin/canal/templates/canal-node.yml.j2
@@ -48,6 +48,7 @@ spec:
         # container hosts.
         - name: flannel
           image: "{{ flannel_image_repo }}:{{ flannel_image_tag }}"
+          imagePullPolicy: {{ k8s_image_pull_policy }}
           env:
             # Cluster name
             - name: CLUSTER_NAME
@@ -117,6 +118,7 @@ spec:
         # host.
         - name: calico-node
           image: "{{ calico_node_image_repo }}:{{ calico_node_image_tag }}"
+          imagePullPolicy: {{ k8s_image_pull_policy }}
           env:
             # The location of the etcd cluster.
             - name: ETCD_ENDPOINTS

--- a/roles/network_plugin/flannel/templates/flannel-pod.yml
+++ b/roles/network_plugin/flannel/templates/flannel-pod.yml
@@ -18,6 +18,7 @@
     containers:
       - name: "flannel-container"
         image: "{{ flannel_image_repo }}:{{ flannel_image_tag }}"
+        imagePullPolicy: {{ k8s_image_pull_policy }}
         command:
           - "/bin/sh"
           - "-c"


### PR DESCRIPTION
According to http://kubernetes.io/docs/user-guide/images/ :
By default, the kubelet will try to pull each image from the
specified registry. However, if the imagePullPolicy property
of the container is set to IfNotPresent or Never, then a local\
image is used (preferentially or exclusively, respectively).

Use IfNotPresent value to allow images prepared by the download
role dependencies to be effectively used by kubelet without pull
errors resulting apps to stay blocked in PullBackOff/Error state
even when there are images on the localhost exist.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>