### PR TITLE
Fix nginx container download for download_run_once mode

### DIFF
--- a/roles/kubernetes/node/meta/main.yml
+++ b/roles/kubernetes/node/meta/main.yml
@@ -7,7 +7,6 @@ dependencies:
   - role: kubernetes/secrets
   - role: download
     file: "{{ downloads.nginx }}"
-    when: is_kube_master == false and loadbalancer_apiserver_localhost|default(false)
   - role: download
     file: "{{ downloads.testbox }}"
   - role: download


### PR DESCRIPTION
W/o this patch, the "Download containers" task may be skipped
when running on the delegate node due to wrong "when" confition.
Then it fails to upload nginx image to the nodes as well.

Fix download nginx dependency so it always can be pushed to
nodes when download_run_once is enabled.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>