### PR TITLE
Ensure /etc/resolv.conf content for CoreOS

### DIFF
--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -11,6 +11,10 @@
 #nameservers:
 #  - 127.0.0.1
 
+# CoreOS cloud init config file to define /etc/resolv.conf content
+# for hostnet pods and infra needs
+resolveconf_cloud_init_conf: /etc/resolveconf_cloud_init.conf
+
 # Versions
 dnsmasq_version: 2.72
 

--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -21,10 +21,22 @@
   notify:
     - Dnsmasq | reload resolvconf
     - Dnsmasq | reload kubelet
+  when: ansible_os_family != "CoreOS"
+
+- name: Dnsmasq | update resolvconf for CoreOS
+  command: /bin/true
+  notify:
+    - Dnsmasq | apply resolvconf cloud-init
+    - Dnsmasq | reload kubelet
+  when: ansible_os_family == "CoreOS"
 
 - name: Dnsmasq | reload resolvconf
   command: /sbin/resolvconf -u
   ignore_errors: true
+
+- name: Dnsmasq | apply resolvconf cloud-init
+  command: /usr/bin/coreos-cloudinit --from-file {{ resolveconf_cloud_init_conf }}
+  when: ansible_os_family == "CoreOS"
 
 - name: Dnsmasq | reload kubelet
   service:

--- a/roles/dnsmasq/tasks/resolvconf.yml
+++ b/roles/dnsmasq/tasks/resolvconf.yml
@@ -9,6 +9,16 @@
   set_fact:
     resolvconffile: >-
       {%- if resolvconf.rc == 0 -%}/etc/resolvconf/resolv.conf.d/head{%- else -%}/etc/resolv.conf{%- endif -%}
+  when: ansible_os_family != "CoreOS"
+
+- name: target temporary resolvconf cloud init file
+  set_fact:
+    resolvconffile: /tmp/resolveconf_cloud_init_conf
+  when: ansible_os_family == "CoreOS"
+
+- name: create temporary resolveconf cloud init file
+  command: cp -f /etc/resolv.conf "{{ resolvconffile }}"
+  when: ansible_os_family == "CoreOS"
 
 - name: generate search domains to resolvconf
   set_fact:
@@ -100,3 +110,17 @@
   copy: src=dhclient_nodnsupdate dest=/etc/dhcp/dhclient.d/nodnsupdate mode=u+x
   notify: Dnsmasq | restart network
   when: ansible_os_family == "RedHat"
+
+- name: get temporary resolveconf cloud init file content
+  command: cat {{ resolvconffile }}
+  register: cloud_config
+  when: ansible_os_family == "CoreOS"
+
+- name: persist resolvconf cloud init file
+  template:
+    dest: "{{resolveconf_cloud_init_conf}}"
+    src: resolvconf.j2
+    owner: root
+    mode: 0644
+  notify: Dnsmasq | update resolvconf for CoreOS
+  when: ansible_os_family == "CoreOS"

--- a/roles/dnsmasq/templates/resolvconf.j2
+++ b/roles/dnsmasq/templates/resolvconf.j2
@@ -1,0 +1,10 @@
+#cloud-config
+write_files:
+  - path: "/etc/resolv.conf"
+    permissions: "0644"
+    owner: "root"
+    content: |
+    {% for l in cloud_config.stdout_lines %}
+      {{ l }}
+    {% endfor %}
+    #


### PR DESCRIPTION
Use cloud-init config to replace /etc/resolv.conf with the
content for kubelet to properly configure hostnet pods.

Do not use systemd-resolved yet, see
https://coreos.com/os/docs/latest/configuring-dns.html
"Only nss-aware applications can take advantage of the
systemd-resolved cache. Notably, this means that statically
linked Go programs and programs running within Docker/rkt
will use /etc/resolv.conf only, and will not use the
systemd-resolve cache."

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>