### PR TITLE
Update default calico/ctl image tag

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -44,7 +44,7 @@ flannel_image_tag: "{{ flannel_version }}"
 calicoctl_image_repo: "calico/ctl"
 # TODO(apanchenko): v1.0.0-beta can't execute `node run` from Docker container
 # for details see https://github.com/projectcalico/calico-containers/issues/1291
-calicoctl_image_tag: "v0.22.0"
+calicoctl_image_tag: "v1.0.0-beta-18-gf72bc1d"
 calico_node_image_repo: "calico/node"
 calico_node_image_tag: "{{ calico_version }}"
 calico_cni_image_repo: "calico/cni"

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -101,8 +101,8 @@
   environment:
     NO_DEFAULT_POOLS: true
   run_once: true
-  when: (not legacy_calicoctl and
-         "Key not found" in calico_conf.stdout or "nodes" not in calico_conf.stdout)
+  when: not legacy_calicoctl and
+         ("Key not found" in calico_conf.stdout or "nodes" not in calico_conf.stdout)
 
 - name: Calico (old) | Define ipip pool argument
   run_once: true
@@ -129,8 +129,8 @@
   environment:
     NO_DEFAULT_POOLS: true
   run_once: true
-  when: (legacy_calicoctl and
-         "Key not found" in calico_conf.stdout or "nodes" not in calico_conf.stdout)
+  when: legacy_calicoctl and
+         ("Key not found" in calico_conf.stdout or "nodes" not in calico_conf.stdout)
 
 - name: Calico | Get calico configuration from etcd
   command: |-


### PR DESCRIPTION
We no longer need to use v0.22.0 for calicoctl since Kargo has support for new calicoctl CLI format.
Also fixing condition logic for calico pool task.
