### PR TITLE
Fix download dnsmasq image dependency on docker

### DIFF
--- a/docs/large-deployments.md
+++ b/docs/large-deployments.md
@@ -8,8 +8,14 @@ For a large scaled deployments, consider the following configuration changes:
 
 * Override containers' `foo_image_repo` vars to point to intranet registry.
 
-* Override the ``download_run_once: true`` to download binaries and container
-  images only once then push to nodes in batches.
+* Override the ``download_run_once: true`` to download container images only once
+  then push to cluster nodes in batches. The default delegate node
+  for pushing images is the first kube-master. Note, if you have passwordless sudo
+  and docker enabled on the separate admin node, you may want to define the
+  ``download_localhost: true``, which makes that node a delegate for pushing images
+  while running the deployment with ansible. This maybe the case if cluster nodes
+  cannot access each over via ssh or you want to use local docker images as a cache
+  for multiple clusters.
 
 * Adjust the `retry_stagger` global var as appropriate. It should provide sane
   load on a delegate (the first K8s master node) then retrying failed

--- a/roles/dnsmasq/meta/main.yml
+++ b/roles/dnsmasq/meta/main.yml
@@ -2,4 +2,4 @@
 dependencies:
   - role: download
     file: "{{ downloads.dnsmasq }}"
-    when: not skip_dnsmasq|default(false)
+    when: not skip_dnsmasq|default(false) and download_localhost|default(false)

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -55,6 +55,7 @@
   raw: sh -c "mkdir -p /opt/bin; ln -sf /usr/bin/python /opt/bin/python"
   when: "{{ download_delegate == 'localhost' }}"
   delegate_to: localhost
+  ignore_errors: true
   run_once: true
 
 - name: Download | create local directory for saved/loaded container images
@@ -103,7 +104,6 @@
   delegate_to: "{{ download_delegate }}"
   register: saved
   run_once: true
-  become: false
   when: (ansible_os_family != "CoreOS" or download_delegate == "localhost") and download_run_once|bool and download.enabled|bool and download.container|bool and (container_changed|bool or not img.stat.exists)
 
 - name: Download | copy container images to ansible host


### PR DESCRIPTION
When download_run_once with download_localhost is used, docker is
expected to be running on the delegate localhost. That may be not
the case for a non localhost delegate, which is the kube-master
otherwise. Then the dnsmasq role, had it been invoked early before
deployment starts, would fail because of the missing docker dependency.

Fix that dependency on docker and do not pre download dnsmasq image
for the dnsmasq role, if download_localhost is disabled.
Describe download_run_once with download_localhost use case in docs
as well.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>