### PR TITLE
[wip] Fix separate etcd nodes and calico

### DIFF
--- a/roles/etcd/tasks/gen_certs.yml
+++ b/roles/etcd/tasks/gen_certs.yml
@@ -40,8 +40,8 @@
   notify: set etcd_secret_changed
 
 - set_fact:
-    master_certs: ['ca-key.pem', 'admin.pem', 'admin-key.pem', 'member.pem', 'member-key.pem']
-    node_certs: ['ca.pem', 'node.pem', 'node-key.pem']
+    master_certs: ['ca-key.pem', 'admin.pem', 'admin-key.pem']
+    node_certs: ['ca.pem', 'node.pem', 'node-key.pem', 'member.pem', 'member-key.pem']
 
 - name: Gen_certs | Gather etcd master certs
   shell: "tar cfz - -C {{ etcd_cert_dir }} {{ master_certs|join(' ') }} {{ node_certs|join(' ') }}| base64 --wrap=0"

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -78,9 +78,9 @@
       --cacert {{ etcd_cert_dir }}/ca.pem \
       --cert {{ etcd_cert_dir}}/admin.pem \
       --key {{ etcd_cert_dir }}/admin-key.pem \
-      https://localhost:2379/v2/keys/calico/v1/ipam/v4/pool
+      https://{{groups['etcd'][0]}}:2379/v2/keys/calico/v1/ipam/v4/pool
   register: calico_conf
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{groups['kube-master'][0]}}"
   run_once: true
 
 - name: Calico | Check calicoctl version
@@ -138,9 +138,9 @@
       --cacert {{ etcd_cert_dir }}/ca.pem \
       --cert {{ etcd_cert_dir}}/admin.pem \
       --key {{ etcd_cert_dir }}/admin-key.pem \
-      https://localhost:2379/v2/keys/calico/v1/ipam/v4/pool
+      https://{{groups['etcd'][0]}}:2379/v2/keys/calico/v1/ipam/v4/pool
   register: calico_pools_raw
-  delegate_to: "{{groups['etcd'][0]}}"
+  delegate_to: "{{groups['kube-master'][0]}}"
   run_once: true
 
 - set_fact:


### PR DESCRIPTION
Admin certs are only available for kube-master nodes.
When etcd nodes are separate, calico fails to access them with
missing admin certs and etcd fails to configure ETCD_PEER_* env
vars due to missing member certs.

Fix this by switching curls to the first etcd node
and delegate to the first master. This assumes only admin certs
allow to get calico keys from etcd but not member/node certs.
Also move member certs from master_certs to node_certs list as
ETCD(_PEER)_CERT/KEY env vars expects.

Closes https://github.com/kubernetes-incubator/kargo/issues/610

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>