### PR TITLE
Set proxy_timeout to 10m in nginx.conf

### DIFF
--- a/roles/kubernetes/node/templates/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/nginx.conf.j2
@@ -18,7 +18,7 @@ stream {
         server {
             listen        {{ kube_apiserver_port }};
             proxy_pass    kube_apiserver;
-            proxy_timeout 3s;
+            proxy_timeout 10m;
             proxy_connect_timeout 1s;
 
         }


### PR DESCRIPTION
Fixes #655.

This is a teporary solution for long-polling idle connections to
apiserver. It will make Nginx not cut them for the duration of expected
timeout. It will also make Nginx extremely slow in realizing that there
is some issue with connectivity to apiserver as well, so it might not be
perfect permanent solution.