### PR TITLE
Reduce CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,64 +22,42 @@ env:
   matrix:
     # Debian Jessie
     - >-
-      KUBE_NETWORK_PLUGIN=flannel
+      KUBE_NETWORK_PLUGIN=canal
       CLOUD_IMAGE=debian-8
-      CLOUD_REGION=europe-west1-b
+      CLOUD_REGION=europe-west1-d
       CLUSTER_MODE=default
     - >-
       KUBE_NETWORK_PLUGIN=calico
       CLOUD_IMAGE=debian-8
-      CLOUD_REGION=us-central1-c
+      CLOUD_REGION=us-central1-b
       CLUSTER_MODE=default
 
     # Centos 7
     - >-
       KUBE_NETWORK_PLUGIN=flannel
       CLOUD_IMAGE=centos-7
-      CLOUD_REGION=asia-east1-c
+      CLOUD_REGION=europe-west1-d
       CLUSTER_MODE=default
     - >-
       KUBE_NETWORK_PLUGIN=calico
       CLOUD_IMAGE=centos-7
       CLOUD_REGION=europe-west1-b
-      CLUSTER_MODE=default
-    - >-
-      KUBE_NETWORK_PLUGIN=weave
-      CLOUD_IMAGE=centos-7
-      CLOUD_REGION=us-central1-c
       CLUSTER_MODE=default
 
    # Redhat 7
     - >-
-      KUBE_NETWORK_PLUGIN=calico
-      CLOUD_IMAGE=rhel-7
-      CLOUD_REGION=asia-east1-c
-      CLUSTER_MODE=default
-    - >-
       KUBE_NETWORK_PLUGIN=weave
       CLOUD_IMAGE=rhel-7
       CLOUD_REGION=europe-west1-b
-      CLUSTER_MODE=default
-
-    # Ubuntu 16.04
-    - >-
-      KUBE_NETWORK_PLUGIN=canal
-      CLOUD_IMAGE=ubuntu-1604-xenial
-      CLOUD_REGION=us-central1-c
-      CLUSTER_MODE=default
-    - >-
-      KUBE_NETWORK_PLUGIN=weave
-      CLOUD_IMAGE=ubuntu-1604-xenial
-      CLOUD_REGION=asia-east1-c
       CLUSTER_MODE=default
 
     # CoreOS stable
-    - >-
-      KUBE_NETWORK_PLUGIN=weave
-      CLOUD_IMAGE=coreos-stable
-      CLOUD_REGION=europe-west1-b
-      CLUSTER_MODE=default
-      BOOTSTRAP_OS=coreos
+    #- >-
+    #  KUBE_NETWORK_PLUGIN=weave
+    #  CLOUD_IMAGE=coreos-stable
+    #  CLOUD_REGION=europe-west1-a
+    #  CLUSTER_MODE=default
+    #  BOOTSTRAP_OS=coreos
     - >-
       KUBE_NETWORK_PLUGIN=canal
       CLOUD_IMAGE=coreos-stable
@@ -91,28 +69,23 @@ env:
     - >-
       KUBE_NETWORK_PLUGIN=canal
       CLOUD_IMAGE=rhel-7
-      CLOUD_REGION=europe-west1-b
-      CLUSTER_MODE=separate
-    - >-
-      KUBE_NETWORK_PLUGIN=calico
-      CLOUD_IMAGE=ubuntu-1604-xenial
-      CLOUD_REGION=us-central1-a
+      CLOUD_REGION=europe-west1-c
       CLUSTER_MODE=separate
     - >-
       KUBE_NETWORK_PLUGIN=weave
-      CLOUD_IMAGE=debian-8
-      CLOUD_REGION=us-east1-d
+      CLOUD_IMAGE=ubuntu-1604-xenial
+      CLOUD_REGION=us-west1-b
       CLUSTER_MODE=separate
     - >-
       KUBE_NETWORK_PLUGIN=calico
       CLOUD_IMAGE=coreos-stable
-      CLOUD_REGION=asia-east1-c
+      CLOUD_REGION=us-central1-f
       CLUSTER_MODE=separate
       BOOTSTRAP_OS=coreos
 
 matrix:
   allow_failures:
-    - env: KUBE_NETWORK_PLUGIN=weave CLOUD_IMAGE=coreos-stable CLOUD_REGION=europe-west1-b CLUSTER_MODE=default BOOTSTRAP_OS=coreos
+    - env: KUBE_NETWORK_PLUGIN=weave CLOUD_IMAGE=coreos-stable CLOUD_REGION=europe-west1-a CLUSTER_MODE=default BOOTSTRAP_OS=coreos
 
 before_install:
   # Install Ansible.

--- a/docs/test_cases.md
+++ b/docs/test_cases.md
@@ -8,21 +8,15 @@ Here is the test matrix for the Travis CI gates:
 
 |           Network plugin|                  OS type|               GCE region|             Nodes layout|
 |-------------------------|-------------------------|-------------------------|-------------------------|
-|                  flannel|                 debian-8|           europe-west1-b|                  default|
-|                   calico|                 debian-8|            us-central1-c|                  default|
-|                  flannel|                 centos-7|             asia-east1-c|                  default|
+|                    canal|                 debian-8|           europe-west1-d|                  default|
+|                   calico|                 debian-8|            us-central1-b|                  default|
+|                  flannel|                 centos-7|           europe-west1-d|                  default|
 |                   calico|                 centos-7|           europe-west1-b|                  default|
-|                    weave|                 centos-7|            us-central1-c|                  default|
-|                   calico|                   rhel-7|             asia-east1-c|                  default|
 |                    weave|                   rhel-7|           europe-west1-b|                  default|
-|                    canal|       ubuntu-1604-xenial|            us-central1-c|                  default|
-|                    weave|       ubuntu-1604-xenial|             asia-east1-c|                  default|
-|                    weave|            coreos-stable|           europe-west1-b|                  default|
 |                    canal|            coreos-stable|               us-east1-d|                  default|
-|                    canal|                   rhel-7|           europe-west1-b|                 separate|
-|                   calico|       ubuntu-1604-xenial|            us-central1-a|                 separate|
-|                    weave|                 debian-8|               us-east1-d|                 separate|
-|                   calico|            coreos-stable|             asia-east1-c|                 separate|
+|                    canal|                   rhel-7|           europe-west1-c|                 separate|
+|                    weave|       ubuntu-1604-xenial|               us-west1-b|                 separate|
+|                   calico|            coreos-stable|            us-central1-f|                 separate|
 
 Where the nodes layout `default` is that is given in the example inventory file.
 And the `separate` layout is when there is only node of each type, which is a kube master,


### PR DESCRIPTION
Reduce the test cases from 15 to 9, bearing in mind that:
* Disable weave/coreos gate unless its deployment fixed
* If debian/centos7 fails with net plugin X, ubuntu-xenial/rhel-7 will
  likely fail as well
* Canal also covers the flannel plugin deployment, but keep at least one
  of the flannel plugin deployment, unless it's superseded and removed.
* Keep at least one of each OS/plugin family to be tested in the separate
  nodes layout
* Keep at least one of each OS family to be tested against each of the
  plugin types in default nodes layout
* Rebalance GCE regions for instances, replace asia to eu/us as they
  are the longest running jobs.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>