### PR TITLE
Disable logs upload and verbose logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ git:
 env:
   global:
     GCE_USER=travis
-    LOG_LEVEL=-v
     SSH_USER=$GCE_USER
     TEST_ID=$TRAVIS_JOB_NUMBER
     CONTAINER_ENGINE=docker
@@ -146,22 +145,6 @@ script:
   - $HOME/.local/bin/ansible-playbook -i inventory/inventory.ini -e ansible_python_interpreter=${PYPATH} -u $SSH_USER -e ansible_ssh_user=$SSH_USER $SSH_ARGS -b --become-user=root tests/testcases/020_check-create-pod.yml $LOG_LEVEL
     ## Ping the between 2 pod
   - $HOME/.local/bin/ansible-playbook -i inventory/inventory.ini -e ansible_python_interpreter=${PYPATH} -u $SSH_USER -e ansible_ssh_user=$SSH_USER $SSH_ARGS -b --become-user=root tests/testcases/030_check-network.yml $LOG_LEVEL
-
-after_failure:
-  - >
-    $HOME/.local/bin/ansible-playbook -i inventory/inventory.ini -u $SSH_USER
-    -e ansible_ssh_user=$SSH_USER $SSH_ARGS -b --become-user=root -e dir=$HOME
-    -e ansible_python_interpreter=${PYPATH}
-    scripts/collect-info.yaml
-  - >
-    $HOME/.local/bin/ansible-playbook tests/cloud_playbooks/upload-logs-gcs.yml -i "localhost," -c local
-    -e kube_network_plugin=${KUBE_NETWORK_PLUGIN}
-    -e gce_project_id=${GCE_PROJECT_ID}
-    -e gs_key=${GS_ACCESS_KEY_ID}
-    -e gs_skey=${GS_SECRET_ACCESS_KEY}
-    -e ostype=${CLOUD_IMAGE}
-    -e commit=${TRAVIS_COMMIT}
-    -e dir=${HOME}
 
 after_script:
   - >


### PR DESCRIPTION
In order to speed up CI jobs, do not produce -v logs.
Also, disable collecting and uploading logs to GS, unless
the buckets creation issue resolved.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>