### PR TITLE
Update calico-node systemd unit

### DIFF
--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -159,9 +159,19 @@
   template: src=network-environment.j2 dest=/etc/network-environment
   when: ansible_service_mgr in ["sysvinit","upstart"]
 
+- name: Calico (old) | Write calico-node systemd init file
+  template: src=calico-node.service.legacy.j2 dest=/etc/systemd/system/calico-node.service
+  when: ansible_service_mgr == "systemd" and legacy_calicoctl
+  notify: restart calico-node
+
+- name: Calico | Write calico.env for systemd init file
+  template: src=calico.env.j2 dest=/etc/calico/calico.env
+  when: ansible_service_mgr == "systemd" and not legacy_calicoctl
+  notify: restart calico-node
+
 - name: Calico | Write calico-node systemd init file
   template: src=calico-node.service.j2 dest=/etc/systemd/system/calico-node.service
-  when: ansible_service_mgr == "systemd"
+  when: ansible_service_mgr == "systemd" and not legacy_calicoctl
   notify: restart calico-node
 
 - name: Calico | Write calico-node initd script

--- a/roles/network_plugin/calico/templates/calico-node.service.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.j2
@@ -1,28 +1,34 @@
 [Unit]
-Description=Calico per-node agent
-Documentation=https://github.com/projectcalico/calico-docker
-After=docker.service docker.socket
-Wants=docker.socket
+Description=calico-node
+After=docker.service
+Requires=docker.service
 
 [Service]
-User=root
-PermissionsStartOnly=true
-{% if legacy_calicoctl %}
-{% if inventory_hostname in groups['kube-node'] and peer_with_router|default(false)%}
-ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --as={{ local_as }} --detach=false --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
-{% else %}
-ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --detach=false --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
-{% endif %}
-{% else %}
-{% if inventory_hostname in groups['kube-node'] and peer_with_router|default(false)%}
-ExecStart={{ bin_dir }}/calicoctl node run --ip={{ip | default(ansible_default_ipv4.address) }} --as={{ local_as }} --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }} {% if calico_network_backend is defined %}--backend={{calico_network_backend }}{% endif %}
-{%     else %}
-ExecStart={{ bin_dir }}/calicoctl node run --ip={{ip | default(ansible_default_ipv4.address) }} --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }} {% if calico_network_backend is defined %}--backend={{calico_network_backend }}{% endif %}
-{% endif %}
-{% endif %}
+EnvironmentFile=/etc/calico/calico.env
+ExecStartPre=-/usr/bin/docker rm -f calico-node
+ExecStart=/usr/bin/docker run --net=host --privileged \
+ --name=calico-node \
+ -e IP=${CALICO_IP} \
+ -e IP6=${CALICO_IP6} \
+ -e CALICO_NETWORKING_BACKEND=${CALICO_NETWORKING_BACKEND} \
+ -e AS=${CALICO_AS} \
+ -e NO_DEFAULT_POOLS=${CALICO_NO_DEFAULT_POOLS} \
+ -e CALICO_LIBNETWORK_ENABLED=${CALICO_LIBNETWORK_ENABLED} \
+ -e ETCD_ENDPOINTS=${ETCD_ENDPOINTS} \
+ -e ETCD_CA_CERT_FILE=${ETCD_CA_CERT_FILE} \
+ -e ETCD_CERT_FILE=${ETCD_CERT_FILE} \
+ -e ETCD_KEY_FILE=${ETCD_KEY_FILE} \
+ -v /var/log/calico:/var/log/calico \
+ -v /run/docker/plugins:/run/docker/plugins \
+ -v /lib/modules:/lib/modules \
+ -v /var/run/calico:/var/run/calico \
+ -v {{ calico_cert_dir }}:{{ calico_cert_dir }}:ro \
+ {{ calico_node_image_repo }}:{{ calico_node_image_tag }}
 
 Restart=always
 RestartSec=10s
+
+ExecStop=-/usr/bin/docker stop calico-node
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/network_plugin/calico/templates/calico-node.service.legacy.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.legacy.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=Calico per-node agent
+Documentation=https://github.com/projectcalico/calico-docker
+After=docker.service docker.socket
+Wants=docker.socket
+
+[Service]
+User=root
+PermissionsStartOnly=true
+{% if inventory_hostname in groups['kube-node'] and peer_with_router|default(false)%}
+ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --as={{ local_as }} --detach=false --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
+{% else %}
+ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --detach=false --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
+{% endif %}
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/network_plugin/calico/templates/calico.env.j2
+++ b/roles/network_plugin/calico/templates/calico.env.j2
@@ -1,0 +1,14 @@
+ETCD_ENDPOINTS="{{ etcd_access_endpoint }}"
+ETCD_CA_CERT_FILE="{{ calico_cert_dir }}/ca_cert.crt"
+ETCD_CERT_FILE="{{ calico_cert_dir }}/cert.crt"
+ETCD_KEY_FILE="{{ calico_cert_dir }}/key.pem"
+CALICO_IP="{{ip | default(ansible_default_ipv4.address) }}"
+CALICO_IP6=""
+{% if calico_network_backend is defined %}
+CALICO_NETWORKING_BACKEND="{{calico_network_backend }}"
+{% endif %}
+{% if inventory_hostname in groups['kube-node'] and peer_with_router|default(false)%}
+CALICO_AS="{{ local_as }}"
+{% endif %}
+CALICO_NO_DEFAULT_POOLS="true"
+CALICO_LIBNETWORK_ENABLED="true"


### PR DESCRIPTION
New calicoctl does not support --detach=false option, so we should
use a recommended way to run calico-node service:
http://docs.projectcalico.org/v2.0/usage/configuration/as-service

Closes #674, #675