### PR TITLE
Add dbus socket dir to kube-proxy

### DIFF
--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -37,6 +37,9 @@ spec:
     - mountPath: /etc/kubernetes/ssl
       name: "etc-kube-ssl"
       readOnly: true
+    - mountPath: /var/run/dbus
+      name: "var-run-dbus"
+      readOnly: false
   volumes:
   - name: ssl-certs-host
     hostPath:
@@ -47,3 +50,6 @@ spec:
   - name: "etc-kube-ssl"
     hostPath:
       path: "/etc/kubernetes/ssl"
+  - name: "var-run-dbus"
+    hostPath:
+      path: "/var/run/dbus"


### PR DESCRIPTION
Removes error in kube-proxy: "Could not connect to D-Bus system bus"