### PR TITLE
Fix ipv4 forwarding on GCE

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -69,6 +69,17 @@
 - include: azure-credential-check.yml
   when: cloud_provider is defined and cloud_provider == 'azure'
 
+- name: Fix ipv4 forward rule in GCE security policy
+  lineinfile:
+    dest: /etc/sysctl.d/11-gce-network-security.conf
+    regexp: '^net.ipv4.ip_forward='
+    line: 'net.ipv4.ip_forward=1'
+    state: present
+    create: yes
+    backup: yes
+    validate: 'sysctl -f %s'
+  when: cloud_provider is defined and cloud_provider == 'gce'
+
 - name: Create cni directories
   file:
     path: "{{ item }}"


### PR DESCRIPTION
ipv4 forwarding gets broken when restarting networking, which
breaks all networking for all pods.