### PR TITLE
Re-enable debian-8-kubespray image for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,12 @@ env:
     # Debian Jessie
     - >-
       KUBE_NETWORK_PLUGIN=canal
-      CLOUD_IMAGE=debian-8
+      CLOUD_IMAGE=debian-8-kubespray
       CLOUD_REGION=europe-west1-d
       CLUSTER_MODE=default
     - >-
       KUBE_NETWORK_PLUGIN=calico
-      CLOUD_IMAGE=debian-8
+      CLOUD_IMAGE=debian-8-kubespray
       CLOUD_REGION=us-central1-b
       CLUSTER_MODE=default
 


### PR DESCRIPTION
debian-8 image is missing memory cgroup, so it can't spawn pods.