### PR TITLE
Calico: fix peering with routers for new version

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -23,7 +23,7 @@ calicoctl status
 * Show the configured network subnet for containers
 
 ```
- calicoctl get ippool -o wide
+calicoctl get ippool -o wide
 ```
 
 or for versions prior *v1.0.0*:

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -196,17 +196,18 @@
   shell: "{{ bin_dir }}/calicoctl config set nodeToNodeMesh off"
   when: (not legacy_calicoctl and
          peer_with_router|default(false) and inventory_hostname in groups['kube-node'])
+  run_once: true
 
 - name: Calico | Configure peering with router(s)
   shell: >
    echo '{
-   "kind": "bgppeer",
-   "spec": {"asNumber": {{ item.as }}},
+   "kind": "bgpPeer",
+   "spec": {"asNumber": "{{ item.as }}"},
    "apiVersion": "v1",
-   "metadata": {"node": "rack1-host1", "scope": "node", "peerIP": "{{ item.router_id }}"}
+   "metadata": {"node": "{{ inventory_hostname }}", "scope": "node", "peerIP": "{{ item.router_id }}"}
    }'
    | {{ bin_dir }}/calicoctl create -f -
-  with_items: peers
+  with_items: "{{ peers|default([]) }}"
   when: (not legacy_calicoctl and
          peer_with_router|default(false) and inventory_hostname in groups['kube-node'])
 
@@ -214,9 +215,10 @@
   shell: "{{ bin_dir }}/calicoctl bgp node-mesh off"
   when: (legacy_calicoctl and
          peer_with_router|default(false) and inventory_hostname in groups['kube-node'])
+  run_once: true
 
 - name: Calico (old) | Configure peering with router(s)
   shell: "{{ bin_dir }}/calicoctl node bgp peer add {{ item.router_id }} as {{ item.as }}"
-  with_items: peers
+  with_items: "{{ peers|default([]) }}"
   when: (legacy_calicoctl and
          peer_with_router|default(false) and inventory_hostname in groups['kube-node'])

--- a/roles/network_plugin/calico/templates/calico-node.service.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.j2
@@ -8,6 +8,7 @@ EnvironmentFile=/etc/calico/calico.env
 ExecStartPre=-/usr/bin/docker rm -f calico-node
 ExecStart=/usr/bin/docker run --net=host --privileged \
  --name=calico-node \
+ -e HOSTNAME=${CALICO_HOSTNAME} \
  -e IP=${CALICO_IP} \
  -e IP6=${CALICO_IP6} \
  -e CALICO_NETWORKING_BACKEND=${CALICO_NETWORKING_BACKEND} \

--- a/roles/network_plugin/calico/templates/calico.env.j2
+++ b/roles/network_plugin/calico/templates/calico.env.j2
@@ -12,3 +12,4 @@ CALICO_AS="{{ local_as }}"
 {% endif %}
 CALICO_NO_DEFAULT_POOLS="true"
 CALICO_LIBNETWORK_ENABLED="true"
+CALICO_HOSTNAME="{{ inventory_hostname }}"

--- a/roles/network_plugin/calico/templates/cni-calico.conf.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conf.j2
@@ -1,5 +1,6 @@
 {
   "name": "calico-k8s-network",
+  "hostname": "{{ inventory_hostname }}",
   "type": "calico",
   "etcd_endpoints": "{{ etcd_access_endpoint }}",
   "etcd_cert_file": "{{ etcd_cert_dir }}/node.pem",


### PR DESCRIPTION
In new `calicoctl` version nodes peering with routers is broken. We need to use predictable node names for calico-node and the same names in calico `bgpPeer` resources.