### PR TITLE
add cluster-signing to kube-controller-manager

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -18,6 +18,8 @@ spec:
     - --leader-elect=true
     - --service-account-private-key-file={{ kube_cert_dir }}/apiserver-key.pem
     - --root-ca-file={{ kube_cert_dir }}/ca.pem
+    - --cluster-signing-cert-file={{ kube_cert_dir }}/ca.pem
+    - --cluster-signing-key-file={{ kube_cert_dir }}/ca-key.pem
     - --enable-hostpath-provisioner={{ kube_hostpath_dynamic_provisioner }}
     - --v={{ kube_log_level }}
 {% if cloud_provider is defined and cloud_provider in ["openstack", "azure"] %}


### PR DESCRIPTION
kube-controller-manager's cluster signing cert and key points by default to not
existing `/etc/kubernetes/ca/ca.pem` and `/etc/kubernetes/ca/ca.key` [docs][1]

[1]: http://kubernetes.io/docs/admin/kube-controller-manager/#options