### PR TITLE
Fix possible problems with legacy calicoctl

### DIFF
--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Calico | Check calicoctl version
+  run_once: true
+  set_fact:
+    legacy_calicoctl: "{{ calicoctl_image_tag | version_compare('v1.0.0', '<') }}"
+
 - name: Calico | Write Calico cni config
   template:
     src: "cni-calico.conf.j2"
@@ -69,11 +74,6 @@
   register: calico_conf
   delegate_to: "{{groups['etcd'][0]}}"
   run_once: true
-
-- name: Calico | Check calicoctl version
-  run_once: true
-  set_fact:
-    legacy_calicoctl: "{{ calicoctl_image_tag | version_compare('v1.0.0', '<') }}"
 
 - name: Calico | Configure calico network pool
   shell: >

--- a/roles/network_plugin/calico/templates/cni-calico.conf.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conf.j2
@@ -1,6 +1,8 @@
 {
   "name": "calico-k8s-network",
+{% if not legacy_calicoctl %}
   "hostname": "{{ inventory_hostname }}",
+{% endif %}
   "type": "calico",
   "etcd_endpoints": "{{ etcd_access_endpoint }}",
   "etcd_cert_file": "{{ etcd_cert_dir }}/node.pem",


### PR DESCRIPTION
When running legacy calicoctl we do not specify calico hostname in calico-node container thus we should not specify it in CNI config.

Also move 'legacy_calicoctl' set_fact task to the top.