### PR TITLE
Change GCE sysctls placement and docs

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -71,3 +71,8 @@ you'll need to edit the inventory and add a and a hostvar `local_as` by node.
 ```
 node1 ansible_ssh_host=95.54.0.12 local_as=xxxxxx
 ```
+
+Cloud providers configuration
+=============================
+
+Please refer to the official documentation, for example [GCE configuration](http://docs.projectcalico.org/v1.5/getting-started/docker/installation/gce) requires a security rule for calico ip-ip tunnels. Note, calico is always configured with ``ipip: true`` if the cloud provider was defined.

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -71,7 +71,7 @@
 
 - name: Fix ipv4 forward rule in GCE security policy
   lineinfile:
-    dest: /etc/sysctl.d/11-gce-network-security.conf
+    dest: /etc/sysctl.d/99-sysctl.conf
     regexp: '^net.ipv4.ip_forward='
     line: 'net.ipv4.ip_forward=1'
     state: present


### PR DESCRIPTION
Override GCE sysctl in /etc/sysctl.d/99-sysctl.conf instead of
the /etc/sysctl.d/11-gce-network-security.conf. It is recreated
by GCE, f.e. if gcloud CLI invokes some security related changes,
thus losing customizations we want to be persistent.

Update cloud providers firewall requirements in calico docs.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>