### PR TITLE
Convert docker_versioned_pkg dict keys to string

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,4 +1,4 @@
-docker_version: 1.10
+docker_version: '1.10'
 
 docker_package_info:
   pkgs:

--- a/roles/docker/vars/debian.yml
+++ b/roles/docker/vars/debian.yml
@@ -2,16 +2,16 @@ docker_kernel_min_version: '3.2'
 
 # https://apt.dockerproject.org/repo/dists/debian-wheezy/main/filelist
 docker_versioned_pkg:
-  latest: docker-engine
-  1.9: docker-engine=1.9.1-0~{{ ansible_distribution_release|lower }}
-  1.10: docker-engine=1.10.3-0~{{ ansible_distribution_release|lower }}
-  1.11: docker-engine=1.11.2-0~{{ ansible_distribution_release|lower }}
-  1.12: docker-engine=1.12.1-0~{{ ansible_distribution_release|lower }}
+  'latest': docker-engine
+  '1.9': docker-engine=1.9.1-0~{{ ansible_distribution_release|lower }}
+  '1.10': docker-engine=1.10.3-0~{{ ansible_distribution_release|lower }}
+  '1.11': docker-engine=1.11.2-0~{{ ansible_distribution_release|lower }}
+  '1.12': docker-engine=1.12.1-0~{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - name: "{{ docker_versioned_pkg[docker_version] }}"
+    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
       force: yes
 
 docker_repo_key_info:

--- a/roles/docker/vars/fedora.yml
+++ b/roles/docker/vars/fedora.yml
@@ -1,16 +1,16 @@
 docker_kernel_min_version: '0'
 
 docker_versioned_pkg:
-  latest: docker
-  1.9: docker-1:1.9.1
-  1.10: docker-1:1.10.1
-  1.11: docker-1:1.11.2
-  1.12: docker-1:1.12.1
+  'latest': docker
+  '1.9': docker-1:1.9.1
+  '1.10': docker-1:1.10.1
+  '1.11': docker-1:1.11.2
+  '1.12': docker-1:1.12.1
 
 docker_package_info:
   pkg_mgr: dnf
   pkgs:
-    - name: "{{ docker_versioned_pkg[docker_version] }}"
+    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/docker/vars/ubuntu-16.04.yml
+++ b/roles/docker/vars/ubuntu-16.04.yml
@@ -1,17 +1,17 @@
 ---
-docker_version: 1.11
+docker_version: '1.11'
 docker_kernel_min_version: '3.2'
 
 # https://apt.dockerproject.org/repo/dists/ubuntu-xenial/main/filelist
 docker_versioned_pkg:
-  latest: docker-engine
-  1.11: docker-engine=1.11.1-0~{{ ansible_distribution_release|lower }}
-  1.12: docker-engine=1.12.1-0~{{ ansible_distribution_release|lower }}
+  'latest': docker-engine
+  '1.11': docker-engine=1.11.1-0~{{ ansible_distribution_release|lower }}
+  '1.12': docker-engine=1.12.1-0~{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - name: "{{ docker_versioned_pkg[docker_version] }}"
+    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
       force: yes
 
 docker_repo_key_info:

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -3,16 +3,16 @@ docker_kernel_min_version: '3.2'
 
 # https://apt.dockerproject.org/repo/dists/ubuntu-trusty/main/filelist
 docker_versioned_pkg:
-  latest: docker-engine
-  1.9: docker-engine=1.9.0-0~{{ ansible_distribution_release|lower }}
-  1.10: docker-engine=1.10.3-0~{{ ansible_distribution_release|lower }}
-  1.11: docker-engine=1.11.1-0~{{ ansible_distribution_release|lower }}
-  1.12: docker-engine=1.12.1-0~{{ ansible_distribution_release|lower }}
+  'latest': docker-engine
+  '1.9': docker-engine=1.9.0-0~{{ ansible_distribution_release|lower }}
+  '1.10': docker-engine=1.10.3-0~{{ ansible_distribution_release|lower }}
+  '1.11': docker-engine=1.11.1-0~{{ ansible_distribution_release|lower }}
+  '1.12': docker-engine=1.12.1-0~{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - name: "{{ docker_versioned_pkg[docker_version] }}"
+    - name: "{{ docker_versioned_pkg[docker_version | string] }}"
       force: yes
 
 docker_repo_key_info:


### PR DESCRIPTION
This will allow to use '-e docker_version=1.12' in ansible playbook execution. It's also backward-compatible and will work with floating docker_version format in custom yaml files.

Closes #702