### PR TITLE
Better support for CentOS 7 on Azure

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -3,6 +3,8 @@
   any_errors_fatal: true
   gather_facts: false
   vars:
+    # Need to disable pipelining for bootstrap-os as some systems have requiretty in sudoers set, which makes pipelining
+    # fail. bootstrap-os fixes this on these systems, so in later plays it can be enabled.
     ansible_ssh_pipelining: false
   roles:
     - bootstrap-os

--- a/cluster.yml
+++ b/cluster.yml
@@ -2,6 +2,8 @@
 - hosts: all
   any_errors_fatal: true
   gather_facts: false
+  vars:
+    ansible_ssh_pipelining: false
   roles:
     - bootstrap-os
   tags:

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,4 +1,4 @@
-# Valid bootstrap options (required): ubuntu, coreos, none
+# Valid bootstrap options (required): ubuntu, coreos, centos, none
 bootstrap_os: none
 
 # Directory where the binaries will be installed

--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Check presence of fastestmirror.conf
+  stat: path=/etc/yum/pluginconf.d/fastestmirror.conf
+  register: fastestmirror
+
+# fastestmirror plugin actually slows down Ansible deployments
+- name: Disable fastestmirror plugin
+  lineinfile:
+    dest: /etc/yum/pluginconf.d/fastestmirror.conf
+    regexp: "^enabled=.*"
+    line: "enabled=0"
+    state: present
+  when: fastestmirror.stat.exists

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -4,3 +4,5 @@
 
 - include: bootstrap-coreos.yml
   when: bootstrap_os == "coreos"
+
+- include: setup-pipelining.yml

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -5,4 +5,7 @@
 - include: bootstrap-coreos.yml
   when: bootstrap_os == "coreos"
 
+- include: bootstrap-centos.yml
+  when: bootstrap_os == "centos"
+
 - include: setup-pipelining.yml

--- a/roles/bootstrap-os/tasks/setup-pipelining.yml
+++ b/roles/bootstrap-os/tasks/setup-pipelining.yml
@@ -1,0 +1,6 @@
+---
+# Remove requiretty to make ssh pipelining work
+
+- name: Remove require tty
+  lineinfile: regexp="^\w+\s+requiretty" dest=/etc/sudoers state=absent
+

--- a/roles/kubernetes/preinstall/tasks/growpart-azure-centos-7.yml
+++ b/roles/kubernetes/preinstall/tasks/growpart-azure-centos-7.yml
@@ -1,5 +1,7 @@
 ---
 
+# Running growpart seems to be only required on Azure, as other Cloud Providers do this at boot time
+
 - name: install growpart
   package: name=cloud-utils-growpart state=latest
 

--- a/roles/kubernetes/preinstall/tasks/growpart-centos-7.yml
+++ b/roles/kubernetes/preinstall/tasks/growpart-centos-7.yml
@@ -1,0 +1,23 @@
+---
+
+- name: install growpart
+  package: name=cloud-utils-growpart state=latest
+
+- name: check if growpart needs to be run
+  command: growpart -N /dev/sda 1
+  failed_when: False
+  changed_when: "'NOCHANGE:' not in growpart_needed.stdout"
+  register: growpart_needed
+
+- name: check fs type
+  command: file -Ls /dev/sda1
+  changed_when: False
+  register: fs_type
+
+- name: run growpart
+  command: growpart /dev/sda 1
+  when: growpart_needed.changed
+
+- name: run xfs_growfs
+  command: xfs_growfs /dev/sda1
+  when: growpart_needed.changed and 'XFS' in fs_type.stdout

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -181,8 +181,14 @@
 - include: resolvconf.yml
   tags: [bootstrap-os, resolvconf]
   
-- include: growpart-centos-7.yml
-  when: ansible_distribution in ["CentOS","RedHat"] and
+- name: Check if we are running inside a Azure VM
+  stat: path=/var/lib/waagent/
+  register: azure_check
+  tags: bootstrap-os
+
+- include: growpart-azure-centos-7.yml
+  when: azure_check.stat.exists and
+        ansible_distribution in ["CentOS","RedHat"] and
         ansible_distribution_major_version >= 7
   tags: bootstrap-os
 

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -180,3 +180,9 @@
 
 - include: resolvconf.yml
   tags: [bootstrap-os, resolvconf]
+  
+- include: growpart-centos-7.yml
+  when: ansible_distribution in ["CentOS","RedHat"] and
+        ansible_distribution_major_version >= 7
+  tags: bootstrap-os
+


### PR DESCRIPTION
This PR adds 3 things which I needed on Azure and CentOS
- Disable fastestmirror yum plugin. This plugin is know to actually slow down yum on CentOS/RedHat when used from Ansible
- Add ability to grow the root partition to the actual block device size. This probably only affects CentOS on Azure. I know from other Cloud Providers (e.g. AWS) that they do the growing automatically (at least on debian/ubuntu). The implementation currently only handles XFS, as it is the default FS on CentOS. If other FS types are needed, this can be added later.
- Remove requiretty from sudoers file. As no one else had problems with pipelining before, I'd suspect that this is again Azure specific. On other systems, this should be a noop.