### PR TITLE
Add support for cloud-provider based networking

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -79,6 +79,7 @@ etcd_multiaccess: true
 loadbalancer_apiserver_localhost: true
 
 # Choose network plugin (calico, weave or flannel)
+# Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
 kube_network_plugin: flannel
 
 # Kubernetes internal network for services, unused block of space.

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -150,6 +150,7 @@ dns_server: "{{ kube_service_addresses|ipaddr('net')|ipaddr(2)|ipaddr('address')
 #azure_subnet_name:
 #azure_security_group_name:
 #azure_vnet_name:
+#azure_route_table_name:
 
 
 ## Set these proxy values in order to update docker daemon to use proxies

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -28,6 +28,11 @@ spec:
 {% elif cloud_provider is defined and cloud_provider == "aws" %}
     - --cloud-provider={{cloud_provider}}
 {% endif %}
+{% if kube_network_plugin is defined and kube_network_plugin == 'cloud' %}
+    - --allocate-node-cidrs=true
+    - --configure-cloud-routes=true
+    - --cluster-cidr={{ kube_pods_subnet }}
+{% endif %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -28,7 +28,8 @@ KUBELET_NETWORK_PLUGIN="--network-plugin=cni --network-plugin-dir=/etc/cni/net.d
 {% elif kube_network_plugin is defined and kube_network_plugin == "weave" %}
 DOCKER_SOCKET="--docker-endpoint=unix:/var/run/weave/weave.sock"
 {% elif kube_network_plugin is defined and kube_network_plugin == "cloud" %}
-KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kubenet"
+# Please note that --reconcile-cidr is deprecated and a no-op in Kubernetes 1.5 but still required in 1.4
+KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kubenet --reconcile-cidr=true"
 {% endif %}
 # Should this cluster be allowed to run privileged docker containers
 KUBE_ALLOW_PRIV="--allow-privileged=true"

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -27,6 +27,8 @@ KUBELET_ARGS="--kubeconfig={{ kube_config_dir}}/kubelet.kubeconfig --require-kub
 KUBELET_NETWORK_PLUGIN="--network-plugin=cni --network-plugin-dir=/etc/cni/net.d"
 {% elif kube_network_plugin is defined and kube_network_plugin == "weave" %}
 DOCKER_SOCKET="--docker-endpoint=unix:/var/run/weave/weave.sock"
+{% elif kube_network_plugin is defined and kube_network_plugin == "cloud" %}
+KUBELET_NETWORK_PLUGIN="--hairpin-mode=promiscuous-bridge --network-plugin=kubenet"
 {% endif %}
 # Should this cluster be allowed to run privileged docker containers
 KUBE_ALLOW_PRIV="--allow-privileged=true"

--- a/roles/kubernetes/preinstall/tasks/azure-credential-check.yml
+++ b/roles/kubernetes/preinstall/tasks/azure-credential-check.yml
@@ -44,4 +44,9 @@
     msg: "azure_vnet_name is missing"
   when: azure_vnet_name is not defined or azure_vnet_name == ""
 
+- name: check azure_route_table_name value
+  fail:
+    msg: "azure_route_table_name is missing"
+  when: azure_route_table_name is not defined or azure_route_table_name == ""
+
 

--- a/roles/network_plugin/cloud/tasks/main.yml
+++ b/roles/network_plugin/cloud/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Cloud | Copy cni plugins from hyperkube
+  command: "/usr/bin/docker run --rm -v /opt/cni/bin:/cnibindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp -r /opt/cni/bin/. /cnibindir/"
+  register: cni_task_result
+  until: cni_task_result.rc == 0
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  changed_when: false

--- a/roles/network_plugin/meta/main.yml
+++ b/roles/network_plugin/meta/main.yml
@@ -12,3 +12,5 @@ dependencies:
  - role: network_plugin/canal
    when: kube_network_plugin == 'canal'
    tags: canal
+ - role: network_plugin/cloud
+   when: kube_network_plugin == 'cloud'


### PR DESCRIPTION
At least some of the cloud providers support networking by using cloud provider specific routing infrastructure, e.g. route tables in AWS and Azure. This PR allows you to specify "cloud" as network_plugin, which configures the controller-manager and kubelet so that the cloud-provider can take over.

I only tested this on Azure, but I'd be happy to have people test this on other cloud providers. Also, I only tested this with the current Kubernetes beta (v1.5.0-beta.2), but I'd assume that this should also work for 1.4.x. The only thing that I'm not sure about is the use of the "--reconcile-cidr" flag which may be needed for 1.4.x as well. This flag was deprecated in 1.5. if I remember correctly.