### PR TITLE
Reduce logging level of kubedns

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/kubedns-rc.yml
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-rc.yml
@@ -56,7 +56,7 @@ spec:
         # command = "/kube-dns"
         - --domain={{ dns_domain }}.
         - --dns-port=10053
-        - --v={{ kube_log_level }}
+        - --v={{ kubedns_log_level | default(1)}}
         ports:
         - containerPort: 10053
           name: dns-local


### PR DESCRIPTION
Kubedns with --v=2 can generate up to 1gb per day in logs.
New default level is 1.
New variable kubedns_log_level can be used to raise verbosity
for debugging.