### PR TITLE
Bump kubedns version to 1.9

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -2,7 +2,7 @@ kube_config_dir: /etc/kubernetes
 kube_namespace: kube-system
 
 # Versions
-kubedns_version: 1.7
+kubedns_version: 1.9
 kubednsmasq_version: 1.3
 exechealthz_version: 1.1
 


### PR DESCRIPTION
Version 1.9 has reduced verbosity for federation dns queries
which flood container logs.