### PR TITLE
Changes targets for bootstrap and preinstall to k8s-cluster

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: k8s-cluster:etcd
   any_errors_fatal: true
   gather_facts: false
   roles:
@@ -12,7 +12,7 @@
   any_errors_fatal: true
   gather_facts: true
 
-- hosts: all:!network-storage
+- hosts: k8s-cluster:etcd:!network-storage
   any_errors_fatal: true
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }


### PR DESCRIPTION
Some environments may include hosts in the inventory that are not part
of the k8s cluster and do not need preinstall or bootstrap performed.
This change retains only the fact gathering with target of `all`.

fixes #714 