### PR TITLE
Fix reverse umount in reset role

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -24,12 +24,12 @@
   shell: docker ps -aq | xargs -r docker rm -fv
 
 - name: reset | gather mounted kubelet dirs
-  shell: mount | grep /var/lib/kubelet | awk '{print $3}'
+  shell: mount | grep /var/lib/kubelet | awk '{print $3}' | tac
   register: mounted_dirs
 
 - name: reset | unmount kubelet dirs
   command: umount {{item}}
-  with_items: '{{ mounted_dirs.stdout_lines | reverse }}'
+  with_items: '{{ mounted_dirs.stdout_lines }}'
 
 - name: reset | delete some files and directories
   file: path={{ item }} state=absent


### PR DESCRIPTION
The Jinja2 filter 'reverse' returned an iterator instead of a list,
resulting in the umount task to fail.

Intead of using the reverse filter, we use 'tac' to reverse the output
of the previous task.