### PR TITLE
Move kube_version to group_vars/all to allow easier changing of version

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -4,6 +4,9 @@ bootstrap_os: none
 # Directory where the binaries will be installed
 bin_dir: /usr/local/bin
 
+## Change this to use another Kubernetes version, e.g. a current beta release
+kube_version: 1.4.6
+
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)
 local_release_dir: "/tmp/releases"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -15,8 +15,6 @@ download_compress: 9
 download_localhost: False
 
 # Versions
-kube_version: v1.4.6
-
 etcd_version: v3.0.6
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download

--- a/roles/uploads/defaults/main.yml
+++ b/roles/uploads/defaults/main.yml
@@ -2,8 +2,6 @@
 local_release_dir: /tmp
 
 # Versions
-kube_version: v1.4.6
-
 etcd_version: v3.0.6
 calico_version: v0.23.0
 calico_cni_version: v1.4.2


### PR DESCRIPTION
Also allows to perform version dependent logic in Ansible roles.