### PR TITLE
Fix kube_version to include 'v' again

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -27,7 +27,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_users_dir: "{{ kube_config_dir }}/users"
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: 1.4.6
+kube_version: v1.4.6
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)


### PR DESCRIPTION
https://github.com/kubernetes-incubator/kargo/pull/736 missed this