### PR TITLE
[wip] Individual etcd ssl certs

### DIFF
--- a/roles/etcd/files/make-ssl-etcd.sh
+++ b/roles/etcd/files/make-ssl-etcd.sh
@@ -16,7 +16,6 @@
 
 set -o errexit
 set -o pipefail
-
 usage()
 {
     cat << EOF
@@ -61,20 +60,40 @@ cd "${tmpdir}"
 mkdir -p "${SSLDIR}"
 
 # Root CA
-openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
-openssl req -x509 -new -nodes -key ca-key.pem -days 10000 -out ca.pem -subj "/CN=etcd-ca" > /dev/null 2>&1
+if [ ! -e ca.pem ]; then
+    openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
+    openssl req -x509 -new -nodes -key ca-key.pem -days 10000 -out ca.pem -subj "/CN=etcd-ca" > /dev/null 2>&1
+fi
 
 # ETCD member
-openssl genrsa -out member-key.pem 2048 > /dev/null 2>&1
-openssl req -new -key member-key.pem -out member.csr -subj "/CN=etcd-member" -config ${CONFIG} > /dev/null 2>&1
-openssl x509 -req -in member.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out member.pem -days 365 -extensions ssl_client -extfile ${CONFIG} > /dev/null 2>&1
+if [ -n "$MASTERS" ]; then
+    for host in $MASTERS; do
+        openssl genrsa -out member-${host}-key.pem 2048 > /dev/null 2>&1
+        openssl req -new -key member-${host}-key.pem -out member-${host}.csr -subj "/CN=etcd-member-${host}" -config ${CONFIG} > /dev/null 2>&1
+        openssl x509 -req -in member-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out member-${host}.pem -days 365 -extensions ssl_client -extfile ${CONFIG} > /dev/null 2>&1
+    done
+else
+    openssl genrsa -out member-key.pem 2048 > /dev/null 2>&1
+    openssl req -new -key member-key.pem -out member.csr -subj "/CN=etcd-member" -config ${CONFIG} > /dev/null 2>&1
+    openssl x509 -req -in member.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out member.pem -days 365 -extensions ssl_client -extfile ${CONFIG} > /dev/null 2>&1
+fi
 
-# Nodes and Admin
-for i in node admin; do
-    openssl genrsa -out ${i}-key.pem 2048 > /dev/null 2>&1
-    openssl req -new -key ${i}-key.pem -out ${i}.csr -subj "/CN=kube-${i}" > /dev/null 2>&1
-    openssl x509 -req -in ${i}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${i}.pem -days 365 -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
-done
+# Node and admin keys
+if [ -n "$HOSTS" ]; then
+    for host in $HOSTS; do
+        for i in node admin; do
+            openssl genrsa -out ${i}-${host}-key.pem 2048 > /dev/null 2>&1
+            openssl req -new -key ${i}-${host}-key.pem -out ${i}-${host}.csr -subj "/CN=kube-${i}-${host}" > /dev/null 2>&1
+            openssl x509 -req -in ${i}-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${i}-${host}.pem -days 365 -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
+        done
+     done
+else
+    for i in node admin; do
+        openssl genrsa -out ${i}-key.pem 2048 > /dev/null 2>&1
+        openssl req -new -key ${i}-key.pem -out ${i}.csr -subj "/CN=kube-${i}" > /dev/null 2>&1
+        openssl x509 -req -in ${i}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out ${i}.pem -days 365 -extensions ssl_client  -extfile ${CONFIG} > /dev/null 2>&1
+    done
+fi
 
 # Install certs
 mv *.pem ${SSLDIR}/

--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -1,26 +1,37 @@
 ---
-- name: "Check_certs | check if the certs have already been generated on first master"
+- name: "Check_certs | check if all certs have already been generated on first master"
   stat:
-    path: "{{ etcd_cert_dir }}/ca.pem"
+    path: "{{ etcd_cert_dir }}/{{ item }}"
   delegate_to: "{{groups['etcd'][0]}}"
   register: etcdcert_master
   run_once: true
+  with_items: >-
+       ['ca.pem',
+       {% set all_etcd_hosts = groups['k8s-cluster']|union(groups['etcd'])|unique %}
+       {% for host in all_etcd_hosts %}
+       'node-{{ host }}-key.pem'
+       {% if not loop.last %}{{','}}{% endif %}
+       {% endfor %}]
 
-- name: "Check_certs | Set default value for 'sync_certs' and 'gen_certs' to false"
+- name: "Check_certs | Set default value for 'sync_certs' and 'etcd_gen_certs' to false"
   set_fact:
     sync_certs: false
-    gen_certs: false
+    etcd_gen_certs: false
 
-- name: "Check_certs | Set 'sync_certs' and 'gen_certs' to true"
+- name: "Check_certs | Set 'sync_certs' and 'etcd_gen_certs' to true"
   set_fact:
     gen_certs: true
-  when: not etcdcert_master.stat.exists
+  when: "not {{item.stat.exists}}"
   run_once: true
+  with_items: "{{etcdcert_master.results}}"
 
 - name: "Check certs | check if a cert already exists"
   stat:
-    path: "{{ etcd_cert_dir }}/ca.pem"
+    path: "{{ etcd_cert_dir }}/node-{{inventory_hostname}}.pem"
   register: etcdcert
+  with_items:
+    - ca.pem
+    - node-{{ inventory_hostname }}.pem
 
 - name: "Check_certs | Set 'sync_certs' to true"
   set_fact:
@@ -28,8 +39,8 @@
   when: >-
       {%- set certs = {'sync': False} -%}
       {%- for server in play_hosts
-         if (not hostvars[server].etcdcert.stat.exists|default(False)) or
-         (hostvars[server].etcdcert.stat.checksum|default('') != etcdcert_master.stat.checksum|default('')) -%}
+         if (not hostvars[server].etcdcert.results[0].stat.exists|default(False)) or
+         (hostvars[server].etcdcert.results[1].stat.checksum|default('') != etcdcert_master.results[1].stat.checksum|default('')) -%}
          {%- set _ = certs.update({'sync': True}) -%}
       {%- endfor -%}
       {{ certs.sync }}

--- a/roles/etcd/tasks/gen_certs.yml
+++ b/roles/etcd/tasks/gen_certs.yml
@@ -34,28 +34,56 @@
 
 - name: Gen_certs | run cert generation script
   command: "{{ etcd_script_dir }}/make-ssl-etcd.sh -f {{ etcd_config_dir }}/openssl.conf -d {{ etcd_cert_dir }}"
+  environment:
+    - MASTERS: "{% for m in groups['etcd'] %}
+                  {% if hostvars[m].sync_certs|default(false) %}
+                    {{ m }}
+                  {% endif %}
+                {% endfor %}"
+    - HOSTS: "{% for h in groups['k8s-cluster'] %}
+                {% if hostvars[h].sync_certs|default(false) %}
+                    {{ h }}
+                {% endif %}
+              {% endfor %}"
   run_once: yes
   delegate_to: "{{groups['etcd'][0]}}"
   when: gen_certs|default(false)
   notify: set etcd_secret_changed
 
 - set_fact:
-    master_certs: ['ca-key.pem', 'admin.pem', 'admin-key.pem', 'member.pem', 'member-key.pem']
-    node_certs: ['ca.pem', 'node.pem', 'node-key.pem']
+    all_master_certs: "['ca-key.pem',
+                      {% for node in groups['etcd'] %}
+                      'admin-{{ node }}.pem',
+                      'admin-{{ node }}-key.pem',
+                      'member-{{ node }}.pem',
+                      'member-{{ node }}-key.pem',
+                      {% endfor %}]"
+    my_master_certs: ['ca-key.pem',
+                     'admin-{{ inventory_hostname }}.pem', 
+                     'admin-{{ inventory_hostname }}-key.pem',
+                     'member-{{ inventory_hostname }}.pem', 
+                     'member-{{ inventory_hostname }}-key.pem'
+                     ]
+    all_node_certs: "['ca.pem',
+                    {% for node in groups['k8s-cluster'] %}
+                    'node-{{ node }}.pem',
+                    'node-{{ node }}-key.pem',
+                    {% endfor %}]"
+    my_node_certs: ['ca.pem', 'node-{{ inventory_hostname }}.pem', 'node-{{ inventory_hostname }}-key.pem']
 
 - name: Gen_certs | Gather etcd master certs
-  shell: "tar cfz - -C {{ etcd_cert_dir }} {{ master_certs|join(' ') }} {{ node_certs|join(' ') }}| base64 --wrap=0"
+  shell: "tar cfz - -C {{ etcd_cert_dir }} {{ my_master_certs|join(' ') }} {{ all_node_certs|join(' ') }}| base64 --wrap=0"
   register: etcd_master_cert_data
   delegate_to: "{{groups['etcd'][0]}}"
-  run_once: true
+  #run_once: true
   when: sync_certs|default(false)
   notify: set etcd_secret_changed
 
 - name: Gen_certs | Gather etcd node certs
-  shell: "tar cfz - -C {{ etcd_cert_dir }} {{ node_certs|join(' ') }} | base64 --wrap=0"
+  shell: "tar cfz - -C {{ etcd_cert_dir }} {{ my_node_certs|join(' ') }} | base64 --wrap=0"
   register: etcd_node_cert_data
   delegate_to: "{{groups['etcd'][0]}}"
-  run_once: true
+  #run_once: true
   when: sync_certs|default(false)
   notify: set etcd_secret_changed
 
@@ -109,4 +137,3 @@
 - name: Gen_certs | update ca-certificates (RedHat)
   command: update-ca-trust extract
   when: etcd_ca_cert.changed and ansible_os_family == "RedHat"
-

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -13,9 +13,9 @@ ETCD_INITIAL_CLUSTER={{ etcd_peer_addresses }}
 
 # TLS settings
 ETCD_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem
-ETCD_CERT_FILE={{ etcd_cert_dir }}/node.pem
-ETCD_KEY_FILE={{ etcd_cert_dir }}/node-key.pem
+ETCD_CERT_FILE={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
+ETCD_KEY_FILE={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
 ETCD_PEER_TRUSTED_CA_FILE={{ etcd_cert_dir }}/ca.pem
-ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member.pem
-ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-key.pem
+ETCD_PEER_CERT_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}.pem
+ETCD_PEER_KEY_FILE={{ etcd_cert_dir }}/member-{{ inventory_hostname }}-key.pem
 ETCD_PEER_CLIENT_CERT_AUTH=true

--- a/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
+++ b/roles/kubernetes-apps/ansible/templates/calico-policy-controller.yml.j2
@@ -31,9 +31,9 @@ spec:
             - name: ETCD_CA_CERT_FILE
               value: "{{ etcd_cert_dir }}/ca.pem"
             - name: ETCD_CERT_FILE
-              value: "{{ etcd_cert_dir }}/node.pem"
+              value: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem"
             - name: ETCD_KEY_FILE
-              value: "{{ etcd_cert_dir }}/node-key.pem"
+              value: "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem"
             # Location of the Kubernetes API - this shouldn't need to be
             # changed so long as it is used in conjunction with
             # CONFIGURE_ETC_HOSTS="true".

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - include: pre-upgrade.yml
 
-
 - name: Copy kubectl from hyperkube container
   command: "/usr/bin/docker run --rm -v {{ bin_dir }}:/systembindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp /hyperkube /systembindir/kubectl"
   register: kube_task_result

--- a/roles/kubernetes/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes/master/tasks/pre-upgrade.yml
@@ -23,3 +23,14 @@
   with_items:
     - /etc/systemd/system/kube-apiserver.service
     - /etc/init.d/kube-apiserver
+
+- name: "Purge kube-apiserver manifest if secrets were changed"
+  file:
+    path: /etc/kubernetes/manifests/kube-apiserver.manifest
+    state: absent
+  register: purged_kubeapiserver_manifest
+  when: secret_changed|default(false) or etcd_secret_changed|default(false)
+
+- name: "Pause while waiting for kubelet to delete kube-apiserver pod"
+  pause: seconds=20
+  when: purged_kubeapiserver_manifest.changed

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -18,8 +18,8 @@ spec:
     - --etcd-servers={{ etcd_access_endpoint }}
     - --etcd-quorum-read=true
     - --etcd-cafile={{ etcd_cert_dir }}/ca.pem
-    - --etcd-certfile={{ etcd_cert_dir }}/node.pem
-    - --etcd-keyfile={{ etcd_cert_dir }}/node-key.pem
+    - --etcd-certfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem
+    - --etcd-keyfile={{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem
     - --insecure-bind-address={{ kube_apiserver_insecure_bind_address }}
     - --apiserver-count={{ kube_apiserver_count }}
     - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -26,8 +26,8 @@
     force: yes
   with_items:
     - {s: "ca.pem", d: "ca_cert.crt"}
-    - {s: "node.pem", d: "cert.crt"}
-    - {s: "node-key.pem", d: "key.pem"}
+    - {s: "node-{{ inventory_hostname }}.pem", d: "cert.crt"}
+    - {s: "node-{{ inventory_hostname }}-key.pem", d: "key.pem"}
 
 - name: Calico | Install calicoctl container script
   template:

--- a/roles/network_plugin/calico/templates/cni-calico.conf.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conf.j2
@@ -5,8 +5,8 @@
 {% endif %}
   "type": "calico",
   "etcd_endpoints": "{{ etcd_access_endpoint }}",
-  "etcd_cert_file": "{{ etcd_cert_dir }}/node.pem",
-  "etcd_key_file": "{{ etcd_cert_dir }}/node-key.pem",
+  "etcd_cert_file": "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem",
+  "etcd_key_file": "{{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem",
   "etcd_ca_cert_file": "{{ etcd_cert_dir }}/ca.pem",
   "log_level": "info",
   "ipam": {

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -21,8 +21,8 @@
     force: yes
   with_items:
     - {s: "ca.pem", d: "ca_cert.crt"}
-    - {s: "node.pem", d: "cert.crt"}
-    - {s: "node-key.pem", d: "key.pem"}
+    - {s: "node-{{ inventory_hostname }}.pem", d: "cert.crt"}
+    - {s: "node-{{ inventory_hostname }}-key.pem", d: "key.pem"}
 
 - name: Canal | Set Flannel etcd configuration
   command: |-

--- a/roles/network_plugin/flannel/templates/flannel-pod.yml
+++ b/roles/network_plugin/flannel/templates/flannel-pod.yml
@@ -22,7 +22,7 @@
         command:
           - "/bin/sh"
           - "-c"
-          - "/opt/bin/flanneld -etcd-endpoints {{ etcd_access_endpoint }} -etcd-prefix /{{ cluster_name }}/network -etcd-cafile {{ etcd_cert_dir }}/ca.pem -etcd-certfile {{ etcd_cert_dir }}/node.pem -etcd-keyfile {{ etcd_cert_dir }}/node-key.pem {% if flannel_interface is defined %}-iface {{ flannel_interface }}{% endif %} {% if flannel_public_ip is defined %}-public-ip {{ flannel_public_ip }}{% endif %}"
+          - "/opt/bin/flanneld -etcd-endpoints {{ etcd_access_endpoint }} -etcd-prefix /{{ cluster_name }}/network -etcd-cafile {{ etcd_cert_dir }}/ca.pem -etcd-certfile {{ etcd_cert_dir }}/node-{{ inventory_hostname }}.pem -etcd-keyfile {{ etcd_cert_dir }}/node-{{ inventory_hostname }}-key.pem {% if flannel_interface is defined %}-iface {{ flannel_interface }}{% endif %} {% if flannel_public_ip is defined %}-public-ip {{ flannel_public_ip }}{% endif %}"
         ports:
           - hostPort: 10253
             containerPort: 10253


### PR DESCRIPTION
Each node gets generated its own etcd certificates.
ETCD masters (except for first one) gets only its own copy of the member certificate.
ETCD masters still get a copy of all node certificates.
Rebalanced how to determine when to generate and sync certs.
Trigger restart of kube-apiserver static pod if certs changed.