### PR TITLE
Set net.ipv4.ip_forward=1 on all systems, not only on GCE

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -81,7 +81,7 @@
   when: cloud_provider is defined and cloud_provider == 'azure'
   tags: [cloud-provider, azure, facts]
 
-- name: Fix ipv4 forward rule in GCE security policy
+- name: Enable ip forwarding
   lineinfile:
     dest: /etc/sysctl.d/99-sysctl.conf
     regexp: '^net.ipv4.ip_forward='
@@ -90,8 +90,7 @@
     create: yes
     backup: yes
     validate: 'sysctl -f %s'
-  when: cloud_provider is defined and cloud_provider == 'gce'
-  tags: [cloud-provider, gce, bootstrap-os]
+  tags: bootstrap-os
 
 - name: Create cni directories
   file:


### PR DESCRIPTION
It looks like all cloud providers disable ip forwarding by default.
It only worked due to the docker daemon enabling it on startup, but this stops working when for whatever reason the network is restarted.