### PR TITLE
Fix wrong path for dhclient.conf on RedHat/CentOS

### DIFF
--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -43,7 +43,7 @@
 
 - name: target dhclient conf/hook files for Red Hat family
   set_fact:
-    dhclientconffile: /etc/dhclient.conf
+    dhclientconffile: /etc/dhcp/dhclient.conf
     dhclienthookfile: /etc/dhcp/dhclient.d/zdnsupdate.sh
   when: ansible_os_family == "RedHat"
 


### PR DESCRIPTION
/etc/dhclient.conf is ignored on RedHat/CentOS
Correct location is /etc/dhcp/dhclient.conf