### PR TITLE
Fallback to default resolver if no nameservers

### DIFF
--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -70,7 +70,7 @@
       {%- if skip_dnsmasq|bool and not dns_early|bool -%}
         {{ [ skydns_server ] + upstream_dns_servers|default([]) }}
       {%- elif dns_early|bool -%}
-        {{ upstream_dns_servers|default([default_resolver]) }}
+        {{ upstream_dns_servers|default([]) }}
       {%- else -%}
         {{ [ dns_server ] }}
       {%- endif -%}
@@ -78,6 +78,6 @@
 - name: generate nameservers to resolvconf
   set_fact:
     nameserverentries:
-      nameserver {{( dnsmasq_server + nameservers|default([])) | join(',nameserver ')}}
+      nameserver {{( dnsmasq_server + nameservers|default([default_resolver])) | join(',nameserver ')}}
     supersede_nameserver:
-      supersede domain-name-servers {{( dnsmasq_server + nameservers|default([])) | join(', ') }};
+      supersede domain-name-servers {{( dnsmasq_server + nameservers|default([default_resolver])) | join(', ') }};


### PR DESCRIPTION
Current design expects users to define at least one
nameserver in the nameservers var to backup host OS DNS config
when the K8s cluster DNS service IP is not available and hosts
still have to resolve external or intranet FQDNs.

Fix undefined nameservers to fallback to the default_resolver.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>