### PR TITLE
Revert "Fix wrong path for dhclient.conf on RedHat/CentOS"

### DIFF
--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -43,7 +43,7 @@
 
 - name: target dhclient conf/hook files for Red Hat family
   set_fact:
-    dhclientconffile: /etc/dhcp/dhclient.conf
+    dhclientconffile: /etc/dhclient.conf
     dhclienthookfile: /etc/dhcp/dhclient.d/zdnsupdate.sh
   when: ansible_os_family == "RedHat"
 


### PR DESCRIPTION
Reverts kubernetes-incubator/kargo#755

Rhel-7 GCE image doesn't have the `/etc/dhcp/dhclient.conf` file and there is `/etc/dhclient.conf`, which is a regular file, not a symlink.