### PR TITLE
Fix #781 prevent vagrant asking for password

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,7 +93,7 @@ Vagrant.configure("2") do |config|
         "flannel_interface" => ip,
         "flannel_backend_type" => "host-gw",
         "local_release_dir" => "/vagrant/temp",
-        "download_run_once" => "True"
+        "download_run_once" => "False"
       }
       config.vm.network :private_network, ip: ip
 


### PR DESCRIPTION
When download_run_once=True it will try to first download images to host
running vagrant, then upload the images from vagrant host to the vagrant
vms. While trying to upload the images it will ask for a the vagrant
linux user password.

For small environments this behaviour is unnecessary hence changing the
default to download_run_once=False inside the Vagrantfile seems like a
good fix.