### PR TITLE
Try to fix creation of ssh-bastion.conf on Travis+GCE

### DIFF
--- a/roles/bastion-ssh-config/tasks/main.yml
+++ b/roles/bastion-ssh-config/tasks/main.yml
@@ -16,3 +16,9 @@
 - name: create ssh bastion conf
   become: false
   template: src=ssh-bastion.conf dest="{{ playbook_dir }}/ssh-bastion.conf"
+  when: has_bastion
+
+- name: create empty bastion conf in case no bastion is used
+  become: false
+  copy: content="" dest="{{ playbook_dir }}/ssh-bastion.conf"
+  when: not has_bastion

--- a/roles/bastion-ssh-config/templates/ssh-bastion.conf
+++ b/roles/bastion-ssh-config/templates/ssh-bastion.conf
@@ -1,6 +1,4 @@
-{% if has_bastion %}
 {% set vars={'hosts': ''} %}
-{% set user='' %}
 
 {% for h in groups['all'] %}
 {% if h != 'bastion' %}
@@ -18,4 +16,3 @@ Host {{ bastion_ip }}
 Host {{ vars['hosts'] }}
   ProxyCommand ssh -W %h:%p {{ real_user }}@{{ bastion_ip }}
   StrictHostKeyChecking no
-{% endif %}


### PR DESCRIPTION
This PR tries to fix an Ansible error that @bogdando had on GCE:
```
Failed to get information on remote file (/home/travis/build/bogdando/kargo/ssh-bastion.conf): MODULE FAILURE"
```

It should be safe to merge even if it does not fix the issue. 
