### PR TITLE
Fix wrong path of dhclient on CentOS+Azure

### DIFF
--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -41,15 +41,27 @@
   set_fact: resolvconffile=/tmp/resolveconf_cloud_init_conf
   when: ansible_os_family == "CoreOS"
 
-- name: target dhclient conf/hook files for Red Hat family
+- name: check if /etc/dhclient.conf exists
+  stat: path=/etc/dhclient.conf
+  register: dhclient_stat
+
+- name: target dhclient conf file for /etc/dhclient.conf
   set_fact:
     dhclientconffile: /etc/dhclient.conf
+  when: dhclient_stat.stat.exists
+
+- name: target dhclient conf file for /etc/dhcp/dhclient.conf
+  set_fact:
+    dhclientconffile: /etc/dhcp/dhclient.conf
+  when: not dhclient_stat.stat.exists
+
+- name: target dhclient hook file for Red Hat family
+  set_fact:
     dhclienthookfile: /etc/dhcp/dhclient.d/zdnsupdate.sh
   when: ansible_os_family == "RedHat"
 
-- name: target dhclient conf/hook files for Debian family
+- name: target dhclient hook file for Debian family
   set_fact:
-    dhclientconffile: /etc/dhcp/dhclient.conf
     dhclienthookfile: /etc/dhcp/dhclient-exit-hooks.d/zdnsupdate
   when: ansible_os_family == "Debian"
 


### PR DESCRIPTION
This was alredy fixed in #755 but had to be reverted. This PR should be
more intelligent about deciding which path to use.