### PR TITLE
Revert "Do not forward private domains for upstream resolvers"

### DIFF
--- a/docs/dns-stack.md
+++ b/docs/dns-stack.md
@@ -51,13 +51,6 @@ aforementioned vars:
 * Resolvconf's head/base files are disabled from populating anything into the
   `/etc/resolv.conf`.
 
-It is important to note that multiple search domains combined with high ``ndots``
-values lead to poor performance of DNS stack, so please choose it wisely.
-The dnsmasq DaemonSet can accept lower ``ndots`` values and return NXDOMAIN
-replies for [bogus internal FQDNS](https://github.com/kubernetes/kubernetes/issues/19634#issuecomment-253948954)
-before it even hits the kubedns app. This enables dnsmasq to serve as a
-protective, but still recursive resolver in front of kubedns.
-
 DNS configuration details
 -------------------------
 
@@ -113,7 +106,8 @@ Limitations
   [no way to specify a custom value](https://github.com/kubernetes/kubernetes/issues/33554)
   for the SkyDNS ``ndots`` param via an
   [option for KubeDNS](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-dns/app/options/options.go)
-  add-on, while SkyDNS supports it though.
+  add-on, while SkyDNS supports it though. Thus, DNS SRV records may not work
+  as expected as they require the ``ndots:7``.
 
 * the ``searchdomains`` have a limitation of a 6 names and 256 chars
   length. Due to default ``svc, default.svc`` subdomains, the actual

--- a/roles/dnsmasq/templates/01-kube-dns.conf.j2
+++ b/roles/dnsmasq/templates/01-kube-dns.conf.j2
@@ -7,8 +7,6 @@ addn-hosts=/etc/hosts
 strict-order
 # Forward k8s domain to kube-dns
 server=/{{ dns_domain }}/{{ skydns_server }}
-# Reply NXDOMAIN to private/internal domains requests
-local=/internal./local./lc./{{ private_domains }}
 
 #Set upstream dns servers
 {% if upstream_dns_servers is defined %}
@@ -19,7 +17,7 @@ server={{ srv }}
 server={{ default_resolver }}
 {% endif %}
 
-{% if kube_log_level == '4' %}
+{% if kube_log_level == 4 %}
 log-queries
 {% endif %}
 bogus-priv

--- a/roles/kubernetes-apps/ansible/templates/kubedns-rc.yml
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-rc.yml
@@ -78,16 +78,8 @@ spec:
         - --log-facility=-
         - --cache-size=1000
         - --no-resolv
-        - --server=/{{ dns_domain }}/127.0.0.1#10053
-        - --local=/internal./local./lc./{{ private_domains }}
-{% if upstream_dns_servers is defined %}
-{% for srv in upstream_dns_servers %}
-        - --server={{ srv }}
-{% endfor %}
-{% else %}
-        - --server={{ default_resolver }}
-{% endif %}
-{% if kube_log_level == '4' %}
+        - --server=127.0.0.1#10053
+{% if kube_log_level == 4 %}
         - --log-queries
 {% endif %}
         ports:


### PR DESCRIPTION
Reverts kubernetes-incubator/kargo#722