### PR TITLE
Use different flavors for different CI cases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,7 @@ before_script:
       -e cloud_image=${CLOUD_IMAGE}
       -e inventory_path=${PWD}/inventory/inventory.ini
       -e cloud_region=${CLOUD_REGION}
+      -e cloud_machine_type=${FLAVOR}
 
     # Create cluster
     - >
@@ -127,6 +128,7 @@ before_script:
       -e cloud_image=${CLOUD_IMAGE}
       -e inventory_path=${PWD}/inventory/inventory.ini
       -e cloud_region=${CLOUD_REGION}
+      -e cloud_machine_type=${FLAVOR}
 
 # Test matrix. Leave the comments for markup scripts.
 .coreos_calico_sep_variables: &coreos_calico_sep_variables
@@ -136,6 +138,7 @@ before_script:
   CLOUD_REGION: us-west1-b
   CLUSTER_MODE: separated
   BOOTSTRAP_OS: coreos
+  FLAVOR: f1-micro
 
 .debian8_canal_ha_variables: &debian8_canal_ha_variables
 # stage: deploy-gce-part1
@@ -143,6 +146,7 @@ before_script:
   CLOUD_IMAGE: debian-8-kubespray
   CLOUD_REGION: us-east1-b
   CLUSTER_MODE: ha
+  FLAVOR: n1-standard-1
 
 .rhel7_weave_variables: &rhel7_weave_variables
 # stage: deploy-gce-part1
@@ -150,6 +154,7 @@ before_script:
   CLOUD_IMAGE: rhel-7
   CLOUD_REGION: europe-west1-b
   CLUSTER_MODE: default
+  FLAVOR: g1-small
 
 .centos7_flannel_variables: &centos7_flannel_variables
 # stage: deploy-gce-part2
@@ -157,6 +162,7 @@ before_script:
   CLOUD_IMAGE: centos-7
   CLOUD_REGION: us-west1-a
   CLUSTER_MODE: default
+  FLAVOR: g1-small
 
 .debian8_calico_variables: &debian8_calico_variables
 # stage: deploy-gce-part2
@@ -164,6 +170,7 @@ before_script:
   CLOUD_IMAGE: debian-8-kubespray
   CLOUD_REGION: us-central1-b
   CLUSTER_MODE: default
+  FLAVOR: g1-small
 
 .coreos_canal_variables: &coreos_canal_variables
 # stage: deploy-gce-part2
@@ -172,6 +179,7 @@ before_script:
   CLOUD_REGION: us-east1-b
   CLUSTER_MODE: default
   BOOTSTRAP_OS: coreos
+  FLAVOR: g1-small
 
 .rhel7_canal_sep_variables: &rhel7_canal_sep_variables
 # stage: deploy-gce-special
@@ -179,6 +187,7 @@ before_script:
   CLOUD_IMAGE: rhel-7
   CLOUD_REGION: us-east1-b
   CLUSTER_MODE: separated
+  FLAVOR: f1-micro
 
 .ubuntu_weave_sep_variables: &ubuntu_weave_sep_variables
 # stage: deploy-gce-special
@@ -186,6 +195,7 @@ before_script:
   CLOUD_IMAGE: ubuntu-1604-xenial
   CLOUD_REGION: us-central1-b
   CLUSTER_MODE: separated
+  FLAVOR: f1-micro
 
 .centos7_calico_ha_variables: &centos7_calico_ha_variables
 # stage: deploy-gce-special
@@ -193,6 +203,7 @@ before_script:
   CLOUD_IMAGE: centos-7
   CLOUD_REGION: europe-west1-b
   CLUSTER_MODE: ha
+  FLAVOR: n1-standard-1
 
 .coreos_alpha_weave_ha_variables: &coreos_alpha_weave_ha_variables
 # stage: deploy-gce-special
@@ -201,6 +212,7 @@ before_script:
   CLOUD_REGION: us-west1-a
   CLUSTER_MODE: ha
   BOOTSTRAP_OS: coreos
+  FLAVOR: n1-standard-1
 
 # Builds for PRs only (auto)
 coreos-calico-sep:


### PR DESCRIPTION
The 'separate' cluster mode does not require much RAM, and passes with
micro. Also, use 'small' for 'default' and 'standard' for 'ha'.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>