### PR TITLE
Raise ansible forks for CI test config

### DIFF
--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,6 +1,7 @@
 [ssh_connection]
 pipelining=True
 [defaults]
+forks = 20
 host_key_checking=False
 gathering = smart
 fact_caching = jsonfile


### PR DESCRIPTION
As we raised the flavor from small to standard, raise the ansible
forks from default 5 to 20 to speed up deployment.

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>