### PR TITLE
Do not try to remove etcd-proxy twice

### DIFF
--- a/roles/etcd/tasks/pre_upgrade.yml
+++ b/roles/etcd/tasks/pre_upgrade.yml
@@ -34,10 +34,6 @@
   command: "docker rm -f {{item}}"
   with_items: "{{etcd_proxy_container.stdout_lines}}"
 
-- name: "Pre-upgrade | remove etcd-proxy if it exists"
-  command: "docker rm -f {{item}}"
-  with_items: "{{etcd_proxy_container.stdout_lines}}"
-
 - name: "Pre-upgrade | check if member list is non-SSL"
   command: "{{ bin_dir }}/etcdctl --no-sync --peers={{ etcd_access_addresses | regex_replace('https','http') }} member list"
   register: etcd_member_list


### PR DESCRIPTION
The same task is present twice in pre upgrade of etcd. The second time, the rm -f command fails as the container was just removed.

See issue #810 