### PR TITLE
Set latest stable versions for Calico images

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -21,8 +21,8 @@ download_always_pull: False
 etcd_version: v3.0.6
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: v1.0.0-beta
-calico_cni_version: v1.4.2
+calico_version: "v1.0.0"
+calico_cni_version: "v1.5.5"
 weave_version: v1.6.1
 flannel_version: v0.6.2
 pod_infra_version: 3.0
@@ -43,15 +43,13 @@ etcd_image_tag: "{{ etcd_version }}"
 flannel_image_repo: "quay.io/coreos/flannel"
 flannel_image_tag: "{{ flannel_version }}"
 calicoctl_image_repo: "calico/ctl"
-# TODO(apanchenko): v1.0.0-beta can't execute `node run` from Docker container
-# for details see https://github.com/projectcalico/calico-containers/issues/1291
-calicoctl_image_tag: "v1.0.0-rc3"
+calicoctl_image_tag: "{{ calico_version }}"
 calico_node_image_repo: "calico/node"
 calico_node_image_tag: "{{ calico_version }}"
 calico_cni_image_repo: "calico/cni"
 calico_cni_image_tag: "{{ calico_cni_version }}"
 calico_policy_image_repo: "calico/kube-policy-controller"
-calico_policy_image_tag: latest
+calico_policy_image_tag: "v0.5.1"
 # TODO(adidenko): switch to "calico/routereflector" when
 # https://github.com/projectcalico/calico-bird/pull/27 is merged
 calico_rr_image_repo: "quay.io/l23network/routereflector"

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -17,8 +17,6 @@ kubednsmasq_image_repo: "gcr.io/google_containers/kube-dnsmasq-amd64"
 kubednsmasq_image_tag: "{{ kubednsmasq_version }}"
 exechealthz_image_repo: "gcr.io/google_containers/exechealthz-amd64"
 exechealthz_image_tag: "{{ exechealthz_version }}"
-calico_policy_image_repo: "calico/kube-policy-controller"
-calico_policy_image_tag: latest
 
 # Limits for calico apps
 calico_policy_controller_cpu_limit: 100m
@@ -31,9 +29,9 @@ deploy_netchecker: false
 netchecker_port: 31081
 agent_report_interval: 15
 netcheck_namespace: default
-agent_img: "quay.io/l23network/mcp-netchecker-agent:v0.1"
-server_img: "quay.io/l23network/mcp-netchecker-server:v0.1"
-kubectl_image: "gcr.io/google_containers/kubectl:v0.18.0-120-gaeb4ac55ad12b1-dirty"
+agent_img: "{{ netcheck_agent_img_repo }}:{{ netcheck_tag }}"
+server_img: "{{ netcheck_server_img_repo }}:{{ netcheck_tag }}"
+kubectl_image: "{{ netcheck_kubectl_img_repo }}:{{ netcheck_kubectl_tag }}"
 
 # Limits for netchecker apps
 netchecker_agent_cpu_limit: 30m

--- a/roles/kubernetes-apps/meta/main.yaml
+++ b/roles/kubernetes-apps/meta/main.yaml
@@ -1,3 +1,20 @@
 dependencies:
+  - role: download
+    file: "{{ downloads.calico_policy }}"
+    when: ( enable_network_policy is defined and enable_network_policy == True ) or
+      ( kube_network_plugin == 'canal' )
+    tags: [download, network, canal]
+  - role: download
+    file: "{{ downloads.netcheck_server }}"
+    when: deploy_netchecker
+    tags: [download, netchecker]
+  - role: download
+    file: "{{ downloads.netcheck_agent }}"
+    when: deploy_netchecker
+    tags: [download, netchecker]
+  - role: download
+    file: "{{ downloads.netcheck_kubectl }}"
+    when: deploy_netchecker
+    tags: [download, netchecker]
   - {role: kubernetes-apps/ansible, tags: apps}
   - {role: kubernetes-apps/kpm, tags: [apps, kpm]}


### PR DESCRIPTION
Change version for calico images to v1.0.0. Also bump versions for CNI and policy controller.

Also removing images repo and tag duplication for netchecker and policy controller