### PR TITLE
Rework wildcards matching all nodes

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -5,7 +5,7 @@
     - bastion-ssh-config
   tags: [localhost, bastion]
 
-- hosts: all
+- hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: true
   gather_facts: false
   vars:
@@ -17,12 +17,13 @@
   tags:
     - bootstrap-os
 
-
-- hosts: all
+- hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: true
+  vars:
+    ansible_ssh_pipelining: true
   gather_facts: true
 
-- hosts: all:!network-storage:!bastion
+- hosts: k8s-cluster:etcd:calico-rr
   any_errors_fatal: true
   roles:
     - { role: kubernetes/preinstall, tags: preinstall }


### PR DESCRIPTION
* Re-enable ansible_ssh_pipelining as expected for the cluster.yml
* Do not use 'all' wildcasts for hosts, limit only to k8s-cluster, etcd,
  calico-rr groups instead. Other nodes in inventory are out of Kargo
  scope and it's up to users how to manage them.

Closes https://github.com/kubernetes-incubator/kargo/issues/714

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>