### PR TITLE
README: changed minimal ansible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Requirements
 * The **firewalls are not managed**, you'll need to implement your own rules the way you used to.
 in order to avoid any issue during deployment you should disable your firewall
 * **Copy your ssh keys** to all the servers part of your inventory.
-* **Ansible v2.x and python-netaddr**
+* **Ansible v2.1 (or newer) and python-netaddr**
 
 
 ## Network plugins


### PR DESCRIPTION
As we discussed in #769 we need ansible v2.1.0 to use kargo. In README file still exist 2.x but I had issue with 2.0.0, so we should change this for clarification. 