### PR TITLE
Do not auto-trigger gitlab CI pipeline on PRs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,7 @@ before_script:
   ANSIBLE_KEEP_REMOTE_FILES: "1"
   BOOTSTRAP_OS: none
   LOG_LEVEL: "-vv"
+  MAGIC: "ci check this"
 
 .gce: &gce
   <<: *job
@@ -202,7 +203,7 @@ before_script:
   CLUSTER_MODE: ha
   BOOTSTRAP_OS: coreos
 
-# Builds for PRs only (auto) and triggers (auto)
+# Builds for PRs only (premoderated by unit-tests step) and triggers (auto)
 coreos-calico-sep:
   stage: deploy-gce-part1
   <<: *job
@@ -405,11 +406,15 @@ coreos-alpha-weave-ha:
   except: ['triggers']
   only: ['master', /^pr-.*$/]
 
+# Premoderated with manual actions
 syntax-check:
   <<: *job
   stage: unit-tests
+  before_script:
+    - apt-get -y install jq
   script:
     - ansible-playbook -i inventory/local-tests.cfg -u root -e ansible_ssh_user=root  -b --become-user=root cluster.yml -vvv  --syntax-check
+    - /bin/sh scripts/premoderator.sh
   except: ['triggers']
 
 tox-inventory-builder:

--- a/scripts/premoderator.sh
+++ b/scripts/premoderator.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -eux -o pipefail
+# A naive premoderation script to allow Gitlab CI pipeline on a specific PRs' comment
+# Exits with 0, if the pipeline is good to go
+
+CURL_ARGS="-fs --connect-timeout 5 --max-time 5 --retry-max-time 20 --retry 4 --retry-delay 5"
+MAGIC="${MAGIC:-ci check this}"
+
+# Get PR number from CI_BUILD_REF_NAME
+issue=$(echo ${CI_BUILD_REF_NAME} | perl -ne '/^pr-(\d+)-\S+$/ && print $1')
+# Get the user name from the PR comments with the wanted magic incantation casted
+user=$(curl ${CURL_ARGS} "https://api.github.com/repos/kubernetes-incubator/kargo/issues/${issue}/comments" \
+  | jq -M "map(select(.body | contains (\"$MAGIC\"))) | .[0] .user.login" | tr -d '"')
+# Check for the required user group membership to allow (exit 0) or decline (exit >0) the pipeline
+curl ${CURL_ARGS} "https://api.github.com/orgs/kubernetes-incubator/members/${user}"


### PR DESCRIPTION
For security and resources utilization reasons, do not auto-start CI
for opened/updated PRs.

A member of the kubernetes-incubator github org has first to approve
that the PR is reasonable to test by putting the "ci check this" into
the PR's comments.

If approved that way, the CI pipeline starts as always. Only the 1st step
of the pipeline is premoderatied, the rest will follow each over on
success.

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>