### PR TITLE
Fix pipeline premoderation/unit-tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -415,7 +415,7 @@ syntax-check:
   script:
     - ansible-playbook -i inventory/local-tests.cfg -u root -e ansible_ssh_user=root  -b --become-user=root cluster.yml -vvv  --syntax-check
     - /bin/sh scripts/premoderator.sh
-  except: ['triggers']
+  except: ['triggers', 'master']
 
 tox-inventory-builder:
   stage: unit-tests
@@ -424,4 +424,4 @@ tox-inventory-builder:
     - pip install tox
     - cd contrib/inventory_builder && tox
   when: manual
-  except: ['triggers']
+  except: ['triggers', 'master']

--- a/scripts/premoderator.sh
+++ b/scripts/premoderator.sh
@@ -11,4 +11,5 @@ issue=$(echo ${CI_BUILD_REF_NAME} | perl -ne '/^pr-(\d+)-\S+$/ && print $1')
 user=$(curl ${CURL_ARGS} "https://api.github.com/repos/kubernetes-incubator/kargo/issues/${issue}/comments" \
   | jq -M "map(select(.body | contains (\"$MAGIC\"))) | .[0] .user.login" | tr -d '"')
 # Check for the required user group membership to allow (exit 0) or decline (exit >0) the pipeline
+[ "$user" != "null" ] || exit 1
 curl ${CURL_ARGS} "https://api.github.com/orgs/kubernetes-incubator/members/${user}"


### PR DESCRIPTION
Nothing gets into the master omitting the unit-tests stage, which includes syntax checks and the pipeline auto-run premoderation. Thus, skip the unit-tests stage for the master merges.

Do not run unit-tests for master merges.
Fix the permissive "null" user.

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>