### PR TITLE
Fix etcd cert generation for calico-rr role

### DIFF
--- a/roles/etcd/tasks/gen_certs.yml
+++ b/roles/etcd/tasks/gen_certs.yml
@@ -40,7 +40,7 @@
                     {{ m }}
                   {% endif %}
                 {% endfor %}"
-    - HOSTS: "{% for h in groups['k8s-cluster'] %}
+    - HOSTS: "{% for h in (groups['k8s-cluster'] + groups['calico-rr']|default([]))|unique %}
                 {% if hostvars[h].sync_certs|default(false) %}
                     {{ h }}
                 {% endif %}
@@ -65,7 +65,7 @@
                      'member-{{ inventory_hostname }}-key.pem'
                      ]
     all_node_certs: "['ca.pem',
-                    {% for node in groups['k8s-cluster'] %}
+                    {% for node in (groups['k8s-cluster'] + groups['calico-rr']|default([]))|unique %}
                     'node-{{ node }}.pem',
                     'node-{{ node }}-key.pem',
                     {% endfor %}]"
@@ -88,8 +88,9 @@
     executable: /bin/bash
   register: etcd_node_cert_data
   delegate_to: "{{groups['etcd'][0]}}"
-  when: inventory_hostname in groups['k8s-cluster'] and sync_certs|default(false) and
-        inventory_hostname not in groups['etcd']
+  when: (('calico-rr' in groups and inventory_hostname in groups['calico-rr']) or
+        inventory_hostname in groups['k8s-cluster']) and
+        sync_certs|default(false) and inventory_hostname not in groups['etcd']
   notify: set etcd_secret_changed
 
 - name: Gen_certs | Copy certs on masters

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -21,10 +21,6 @@ global_as_num: "64512"
 # calico_mtu: 1500
 
 # Limits for apps
-calico_rr_memory_limit: 1000M
-calico_rr_cpu_limit: 300m
-calico_rr_memory_requests: 500M
-calico_rr_cpu_requests: 150m
 calico_node_memory_limit: 500M
 calico_node_cpu_limit: 300m
 calico_node_memory_requests: 256M

--- a/roles/network_plugin/calico/rr/defaults/main.yml
+++ b/roles/network_plugin/calico/rr/defaults/main.yml
@@ -5,3 +5,9 @@ global_as_num: "64512"
 
 calico_cert_dir: /etc/calico/certs
 etcd_cert_dir: /etc/ssl/etcd/ssl
+
+# Limits for apps
+calico_rr_memory_limit: 1000M
+calico_rr_cpu_limit: 300m
+calico_rr_memory_requests: 500M
+calico_rr_cpu_requests: 150m


### PR DESCRIPTION
"etcd_node_cert_data" variable is undefinded for "calico-rr" role. This patch adds "calico-rr" nodes to task where "etcd_node_cert_data" variable is registered. Also move calico-rr container resource limits to appropriate defaults file.