### PR TITLE
Non preempt GCE instances for CI

### DIFF
--- a/tests/cloud_playbooks/create-gce.yml
+++ b/tests/cloud_playbooks/create-gce.yml
@@ -24,7 +24,7 @@
         instance_names: "{{instance_names}}"
         machine_type: "{{ cloud_machine_type }}"
         image: "{{ cloud_image }}"
-        preemptible: yes
+        preemptible: no
         service_account_email: "{{ gce_service_account_email }}"
         pem_file: "{{ gce_pem_file | default(omit)}}"
         credentials_file: "{{gce_credentials_file | default(omit)}}"


### PR DESCRIPTION
Revert preemptible GCE instances for CI as they are too
much of UNREACHABLE. Later we could return to them after
figured out how to mitigate preepted instances with
automated CI retries.

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>