### PR TITLE
Make nginx proxy for apiserver bind of configurable address

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -1,6 +1,9 @@
 # change to 0.0.0.0 to enable insecure access from anywhere (not recommended)
 kube_apiserver_insecure_bind_address: 127.0.0.1
 
+# change to 0.0.0.0 to enable insecure access from anywhere on this node (not recommended)
+kube_apiserver_nginx_bind_address: 127.0.0.1
+
 # resolv.conf to base dns config
 kube_resolv_conf: "/etc/resolv.conf"
 

--- a/roles/kubernetes/node/templates/nginx.conf.j2
+++ b/roles/kubernetes/node/templates/nginx.conf.j2
@@ -16,7 +16,7 @@ stream {
         }
 
         server {
-            listen        {{ kube_apiserver_port }};
+            listen        {{ kube_apiserver_nginx_bind_address }}:{{ kube_apiserver_port }};
             proxy_pass    kube_apiserver;
             proxy_timeout 10m;
             proxy_connect_timeout 1s;


### PR DESCRIPTION
See #868. The PR makes the bind address for the nginx proxy to the apiserver configurable, and defaults to `127.0.0.1`.