### PR TITLE
Fix docker dns host scenario with no search domains

### DIFF
--- a/roles/docker/tasks/set_facts_dns.yml
+++ b/roles/docker/tasks/set_facts_dns.yml
@@ -40,13 +40,13 @@
 
 - name: add system nameservers to docker options
   set_fact:
-    docker_dns_servers: "{{ docker_dns_servers + [item] }}"
-  with_items: "{{ system_nameservers.stdout_lines|default([]) }}"
+    docker_dns_servers: "{{ docker_dns_servers | union(system_nameservers.stdout_lines) | unique }}"
+  when: system_nameservers.stdout != ""
 
 - name: add system search domains to docker options
   set_fact:
-    docker_dns_search_domains: "{{ docker_dns_search_domains + [item] }}"
-  with_items: "{{ system_search_domains.stdout.split(' ') }}"
+    docker_dns_search_domains: "{{ docker_dns_search_domains | union(system_search_domains.stdout.split(' ')|default([])) | unique }}"
+  when: system_search_domains.stdout != "" 
 
 - name: check number of nameservers
   fail: msg="Too many nameservers"


### PR DESCRIPTION
Fixes scenario where docker-dns.conf tries to create an empty
search entry