### PR TITLE
Add tasks to undo changes to hosts /etc/resolv.conf and dhclient configs

### DIFF
--- a/roles/kubernetes/preinstall/tasks/dhclient-hooks-undo.yml
+++ b/roles/kubernetes/preinstall/tasks/dhclient-hooks-undo.yml
@@ -1,0 +1,22 @@
+---
+
+# These tasks will undo changes done by kargo in the past if needed (e.g. when upgrading from kargo 2.0.x
+# or when changing resolvconf_mode)
+
+- name: Remove kargo specific config from dhclient config
+  blockinfile:
+    dest: "{{dhclientconffile}}"
+    state: absent
+    backup: yes
+    follow: yes
+    marker: "# Ansible entries {mark}"
+  notify: Preinstall | restart network
+
+- name: Remove kargo specific dhclient hook
+  file: path="{{ dhclienthookfile }}" state=absent
+  notify: Preinstall | restart network
+  when: ansible_os_family != "RedHat"
+
+# We need to make sure the network is restarted early enough so that docker can later pick up the correct system
+# nameservers and search domains
+- meta: flush_handlers

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -175,6 +175,14 @@
   when: dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
   tags: [bootstrap-os, resolvconf]
 
+- include: dhclient-hooks.yml
+  when: dns_mode != 'none' and resolvconf_mode == 'host_resolvconf' and not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+  tags: [bootstrap-os, resolvconf]
+
+- include: dhclient-hooks-undo.yml
+  when: dns_mode != 'none' and resolvconf_mode != 'host_resolvconf' and not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
+  tags: [bootstrap-os, resolvconf]
+
 - name: Check if we are running inside a Azure VM
   stat: path=/var/lib/waagent/
   register: azure_check

--- a/roles/kubernetes/preinstall/tasks/resolvconf.yml
+++ b/roles/kubernetes/preinstall/tasks/resolvconf.yml
@@ -58,7 +58,3 @@
     mode: 0644
   notify: Preinstall | update resolvconf for Container Linux by CoreOS
   when: ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
-
-- include: dhclient-hooks.yml
-  when: not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
-  tags: [bootstrap-os, resolvconf]


### PR DESCRIPTION
This PR will undo changes done to /etc/resolv.conf done by older kargo versions. It will also handle the case when you change the resolvconf_mode from host_resolvconv to docker_dns.

This will not fully work on calico/canal based installations as network restart is skipped for these systems.