### PR TITLE
Don't try to delete kargo specific config from dhclient when file does not exist

### DIFF
--- a/roles/kubernetes/preinstall/tasks/dhclient-hooks-undo.yml
+++ b/roles/kubernetes/preinstall/tasks/dhclient-hooks-undo.yml
@@ -3,6 +3,10 @@
 # These tasks will undo changes done by kargo in the past if needed (e.g. when upgrading from kargo 2.0.x
 # or when changing resolvconf_mode)
 
+- name: Check if dhclient conf file exists
+  stat: path={{dhclientconffile}}
+  register: dhclientconf_check
+
 - name: Remove kargo specific config from dhclient config
   blockinfile:
     dest: "{{dhclientconffile}}"
@@ -10,12 +14,13 @@
     backup: yes
     follow: yes
     marker: "# Ansible entries {mark}"
+  when: dhclientconf_check.stat.exists
   notify: Preinstall | restart network
 
 - name: Remove kargo specific dhclient hook
   file: path="{{ dhclienthookfile }}" state=absent
+  when: dhclienthookfile is defined
   notify: Preinstall | restart network
-  when: ansible_os_family != "RedHat"
 
 # We need to make sure the network is restarted early enough so that docker can later pick up the correct system
 # nameservers and search domains


### PR DESCRIPTION
Also remove the check for != "RedHat" when removing the dhclient hook,
as this had also to be done on other distros. Instead, check if the
dhclienthookfile is defined.