### PR TITLE
Flush handlers before etcd restart

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -15,21 +15,21 @@
 - include: refresh_config.yml
   when: is_etcd_master
 
-- name: Ensure etcd is running
-  service:
-    name: etcd
-    state: started
-    enabled: yes
-  when: is_etcd_master
-
 - name: Restart etcd if binary or certs changed
   command: /bin/true
   notify: restart etcd
   when: etcd_deployment_type == "host" and etcd_copy.stdout_lines and is_etcd_master
     or etcd_secret_changed|default(false)
 
-# Reload systemd before starting service
+# reload-systemd
 - meta: flush_handlers
+
+- name: Ensure etcd is running
+  service:
+    name: etcd
+    state: started
+    enabled: yes
+  when: is_etcd_master
 
 # After etcd cluster is assembled, make sure that
 # initial state of the cluster is in `existing`


### PR DESCRIPTION
systemctl daemon-reload should be run before when task modifies/creates
union for etcd. Otherwise etcd won't be able to start

Closes #892