### PR TITLE
Add tasks to ensure that the first nodes have their directories for cert gen

### DIFF
--- a/roles/etcd/tasks/gen_certs.yml
+++ b/roles/etcd/tasks/gen_certs.yml
@@ -7,7 +7,7 @@
     owner=root
     recurse=yes
 
-- name: Gen_certs | create etcd script dir
+- name: "Gen_certs | create etcd script dir (on {{groups['etcd'][0]}})"
   file:
     path: "{{ etcd_script_dir }}"
     state: directory
@@ -15,7 +15,7 @@
   run_once: yes
   delegate_to: "{{groups['etcd'][0]}}"
 
-- name: Gen_certs | create etcd cert dir (on first etcd)
+- name: "Gen_certs | create etcd cert dir (on {{groups['etcd'][0]}})"
   file:
     path={{ etcd_cert_dir }}
     group={{ etcd_cert_group }}

--- a/roles/etcd/tasks/gen_certs.yml
+++ b/roles/etcd/tasks/gen_certs.yml
@@ -1,12 +1,4 @@
 ---
-
-- name: Gen_certs | create etcd script dir
-  file:
-    path: "{{ etcd_script_dir }}"
-    state: directory
-    owner: root
-  when: inventory_hostname == groups['etcd'][0]
-
 - name: Gen_certs | create etcd cert dir
   file:
     path={{ etcd_cert_dir }}
@@ -14,6 +6,24 @@
     state=directory
     owner=root
     recurse=yes
+
+- name: Gen_certs | create etcd script dir
+  file:
+    path: "{{ etcd_script_dir }}"
+    state: directory
+    owner: root
+  run_once: yes
+  delegate_to: "{{groups['etcd'][0]}}"
+
+- name: Gen_certs | create etcd cert dir (on first etcd)
+  file:
+    path={{ etcd_cert_dir }}
+    group={{ etcd_cert_group }}
+    state=directory
+    owner=root
+    recurse=yes
+  run_once: yes
+  delegate_to: "{{groups['etcd'][0]}}"
 
 - name: Gen_certs | write openssl config
   template:

--- a/roles/kubernetes/secrets/tasks/gen_certs.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs.yml
@@ -1,5 +1,5 @@
 ---
-- name: Gen_certs | Create kubernetes config directory (on master[0])
+- name: "Gen_certs | Create kubernetes config directory (on {{groups['kube-master'][0]}})"
   file:
     path: "{{ kube_config_dir }}"
     state: directory
@@ -9,7 +9,7 @@
   tags: [kubelet, k8s-secrets, kube-controller-manager, kube-apiserver, bootstrap-os, apps, network, master, node]
   when: gen_certs|default(false)
 
-- name: Gen_certs | Create kubernetes script directory (on master[0])
+- name: "Gen_certs | Create kubernetes script directory (on {{groups['kube-master'][0]}})"
   file:
     path: "{{ kube_script_dir }}"
     state: directory

--- a/roles/kubernetes/secrets/tasks/gen_certs.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs.yml
@@ -1,4 +1,24 @@
 ---
+- name: Gen_certs | Create kubernetes config directory (on master[0])
+  file:
+    path: "{{ kube_config_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  tags: [kubelet, k8s-secrets, kube-controller-manager, kube-apiserver, bootstrap-os, apps, network, master, node]
+  when: gen_certs|default(false)
+
+- name: Gen_certs | Create kubernetes script directory (on master[0])
+  file:
+    path: "{{ kube_script_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  tags: [k8s-secrets, bootstrap-os]
+  when: gen_certs|default(false)
+
 - name: Gen_certs | write openssl config
   template:
     src: "openssl.conf.j2"

--- a/roles/kubernetes/secrets/tasks/main.yml
+++ b/roles/kubernetes/secrets/tasks/main.yml
@@ -35,6 +35,41 @@
   when: inventory_hostname in "{{ groups['kube-master'] }}"
   notify: set secret_changed
 
+#
+# The following directory creates make sure that the directories
+# exist on the first master for cases where the first master isn't
+# being run.
+#
+- name: Gen_certs | Create kubernetes config directory (on master[0])
+  file:
+    path: "{{ kube_config_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  tags: [kubelet, k8s-secrets, kube-controller-manager, kube-apiserver, bootstrap-os, apps, network, master, node]
+  when: gen_certs|default(false) or gen_tokens|default(false)
+
+- name: Gen_certs | Create kubernetes script directory (on master[0])
+  file:
+    path: "{{ kube_script_dir }}"
+    state: directory
+    owner: kube
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  tags: [k8s-secrets, bootstrap-os]
+  when: gen_certs|default(false) or gen_tokens|default(false)
+
+- name: Get_tokens | Make sure the tokens directory exits (on master[0])
+  file:
+    path={{ kube_token_dir }}
+    state=directory
+    mode=o-rwx
+    group={{ kube_cert_group }}
+  run_once: yes
+  delegate_to: "{{groups['kube-master'][0]}}"
+  when: gen_tokens|default(false)
+
 - include: gen_certs.yml
   tags: k8s-secrets
 - include: gen_tokens.yml

--- a/roles/kubernetes/secrets/tasks/main.yml
+++ b/roles/kubernetes/secrets/tasks/main.yml
@@ -40,7 +40,7 @@
 # exist on the first master for cases where the first master isn't
 # being run.
 #
-- name: Gen_certs | Create kubernetes config directory (on master[0])
+- name: "Gen_certs | Create kubernetes config directory (on {{groups['kube-master'][0]}})"
   file:
     path: "{{ kube_config_dir }}"
     state: directory
@@ -50,7 +50,7 @@
   tags: [kubelet, k8s-secrets, kube-controller-manager, kube-apiserver, bootstrap-os, apps, network, master, node]
   when: gen_certs|default(false) or gen_tokens|default(false)
 
-- name: Gen_certs | Create kubernetes script directory (on master[0])
+- name: "Gen_certs | Create kubernetes script directory (on {{groups['kube-master'][0]}})"
   file:
     path: "{{ kube_script_dir }}"
     state: directory
@@ -60,7 +60,7 @@
   tags: [k8s-secrets, bootstrap-os]
   when: gen_certs|default(false) or gen_tokens|default(false)
 
-- name: Get_tokens | Make sure the tokens directory exits (on master[0])
+- name: "Get_tokens | Make sure the tokens directory exits (on {{groups['kube-master'][0]}})"
   file:
     path={{ kube_token_dir }}
     state=directory


### PR DESCRIPTION
This PR adds/modifies a few tasks to allow for the playbook to
be run by limit on each node without regard for order.

The changes make sure that all of the directories needed to do
certificate management are on the master[0] or etcd[0] node regardless
of when the playbook gets run on each node.  This allows for separate
ansible playbook runs in parallel that don't have to be synchronized.