### PR TITLE
Fixbug #907

### DIFF
--- a/roles/etcd/templates/deb-etcd-docker.initd.j2
+++ b/roles/etcd/templates/deb-etcd-docker.initd.j2
@@ -50,7 +50,7 @@ do_status()
 #
 do_start()
 {
-    {{ docker_bin_dir }}/docker rm -f {{ etcd_member_name | default("etcd") }} &>/dev/null || true
+    {{ docker_bin_dir }}/docker rm -f {{ etcd_member_name | default("etcd") }} > /dev/null 2>&1 || true
     sleep 1
     start-stop-daemon --background --start --quiet --make-pidfile --pidfile $PID --user $DAEMON_USER --exec $DAEMON -- \
         $DAEMON_ARGS \


### PR DESCRIPTION
etcd didn't start automatically after system reboot on Ubuntu Trusty. The issue seems to be in the initscript. It seems that the command in `line 53` is forked in a sub-shell and the stderr/stdout are not correctly redirected as expected because of the `&>` operator.

This PR can be merged with other bug fixes for a later v2.0.2.