### PR TITLE
Ansible apps should only check for api-server running on the master.

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/main.yaml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yaml
@@ -5,6 +5,7 @@
   until: result.status == 200
   retries: 10
   delay: 6
+  when: inventory_hostname == groups['kube-master'][0]
 
 - name: Kubernetes Apps | Lay Down KubeDNS Template
   template: src={{item.file}} dest={{kube_config_dir}}/{{item.file}}


### PR DESCRIPTION
If this runs on other nodes, it will fail the playbook.