### PR TITLE
Fix setting resolvconf when using rkt deploy mode

### DIFF
--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -17,16 +17,16 @@
     default_resolver: >-
       {%- if cloud_provider is defined and cloud_provider == 'gce' -%}169.254.169.254{%- else -%}8.8.8.8{%- endif -%}
 
-- name: check kubelet
+- name: check if kubelet is configured
   stat:
-    path: "{{ bin_dir }}/kubelet"
-  register: kubelet
+    path: "{{ kube_config_dir }}/kubelet.env"
+  register: kubelet_configured
   changed_when: false
 
 - name: check if early DNS configuration stage
   set_fact:
     dns_early: >-
-      {%- if kubelet.stat.exists -%}false{%- else -%}true{%- endif -%}
+      {%- if kubelet_configured.stat.exists -%}false{%- else -%}true{%- endif -%}
 
 - name: target resolv.conf files
   set_fact:


### PR DESCRIPTION
rkt deploy mode doesn't create {{ bin_dir }}/kubelet, so
let's rely on kubelet.env file instad.