### PR TITLE
Allow to specify number of concurrent DNS queries

### DIFF
--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -11,6 +11,9 @@
 #nameservers:
 #  - 127.0.0.1
 
+dns_forward_max: 150
+cache_size: 1000
+
 # Versions
 dnsmasq_version: 2.72
 

--- a/roles/dnsmasq/templates/01-kube-dns.conf.j2
+++ b/roles/dnsmasq/templates/01-kube-dns.conf.j2
@@ -27,7 +27,8 @@ log-queries
 {% endif %}
 bogus-priv
 no-negcache
-cache-size=1000
+cache-size={{ cache_size }}
+dns-forward-max={{ dns_forward_max }}
 max-cache-ttl=10
 max-ttl=20
 log-facility=-


### PR DESCRIPTION
ndots creates overhead as every pod creates 5 concurrent connections
that are forwarded to sky dns. Under some circumstances dnsmasq may
prevent forwarding traffic with "Maximum number of concurrent DNS
queries reached" in the logs.

This patch allows to configure the number of concurrent forwarded DNS
queries "dns-forward-max" as well as "cache-size" leaving the default
values as they were before.

Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>