### PR TITLE
Rework idempotency checks for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,7 +127,7 @@ before_script:
     ## Advanced DNS checks
     - ansible-playbook -i inventory/inventory.ini -e ansible_python_interpreter=${PYPATH} -u $SSH_USER -e ansible_ssh_user=$SSH_USER $SSH_ARGS -b --become-user=root tests/testcases/040_check-network-adv.yml $LOG_LEVEL
 
-    ## Idempotency checks 1/5 (repeat deployment)
+    ## Idempotency checks 1/4 (partial repeat deployment)
     - >
       if [ "${IDEMPOT_CHECK}" = "true" ]; then
       ansible-playbook -i inventory/inventory.ini -u $SSH_USER -e ansible_ssh_user=$SSH_USER $SSH_ARGS 
@@ -142,7 +142,7 @@ before_script:
       -e local_release_dir=${PWD}/downloads 
       -e etcd_deployment_type=${ETCD_DEPLOYMENT} 
       -e kubelet_deployment_type=${KUBELET_DEPLOYMENT} 
-      cluster.yml;
+      cluster.yml --skip-tags=download --limit=k8s-cluster:kube-master;
       fi
 
     ## Idempotency checks 2/5 (Advanced DNS checks)
@@ -161,7 +161,7 @@ before_script:
       --private-key=${HOME}/.ssh/id_rsa 
       -e bootstrap_os=${BOOTSTRAP_OS} 
       -e ansible_python_interpreter=${PYPATH} 
-      reset.yml;
+      reset.yml --skip-tags=reset_images;
       fi
 
     ## Idempotency checks 4/5 (redeploy after reset)

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -135,6 +135,7 @@ The following tags are defined in playbooks:
 |                    nginx | Configuring LB for kube-apiserver instances
 |                     node | Configuring K8s minion (compute) node role
 |                openstack | Cloud-provider OpenStack
+|             reset_images | Controls if the reset role purges images as well
 |               preinstall | Preliminary configuration steps
 |               resolvconf | Configuring /etc/resolv.conf for hosts/apps
 |                  upgrade | Upgrading, f.e. container images/binaries

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -31,6 +31,7 @@
 
 - name: reset | remove all containers
   shell: "{{ docker_bin_dir }}/docker ps -aq | xargs -r docker rm -fv"
+  tags: [reset_images]
 
 - name: reset | restart docker if needed
   service: name=docker state=restarted

--- a/scripts/gen_tags.sh
+++ b/scripts/gen_tags.sh
@@ -2,7 +2,7 @@
 #Generate MD formatted tags from roles and cluster yaml files
 printf "|%25s |%9s\n" "Tag name" "Used for"
 echo "|--------------------------|---------"
-tags=$(grep -r tags: . | perl -ne '/tags:\s\[?(([\w\-_]+,?\s?)+)/ && printf "%s ", "$1"'|\
+tags=$(grep -Pro 'tags:\s\[.*\]?' . | perl -ne '/tags:\s\[?(([\w\-_]+,?\s?)+)/ && printf "%s ", "$1"'|\
   perl -ne 'print join "\n", split /\s|,/' | sort -u)
 for tag in $tags; do
   match=$(cat docs/ansible.md | perl -ne "/^\|\s+${tag}\s\|\s+((\S+\s?)+)/ && printf \$1")


### PR DESCRIPTION
Shorten idempotency checks run time and split its
coverage over ha, default, separate CI modes:
* Do not reset docker images, controlled by tags
* Limit redeploy to master groups (it still covers
  etcd and minions for later default/ha CI cases)
  and skip download tags.

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>