### PR TITLE
Remove nsenter workaround

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -1,16 +1,23 @@
 #!/bin/bash
-{{ docker_bin_dir }}/docker run --privileged \
---net=host --pid=host --name=kubelet --restart=on-failure:5 \
--v /etc/cni:/etc/cni:ro \
--v /opt/cni:/opt/cni:ro \
--v {{kube_config_dir}}:{{kube_config_dir}} \
--v /sys:/sys \
--v /dev:/dev \
--v {{ docker_daemon_graph }}:/var/lib/docker \
--v /var/run:/var/run \
--v /var/lib/kubelet:/var/lib/kubelet \
---memory={{ kubelet_memory_limit|regex_replace('Mi', 'M') }} --cpu-shares={{ kubelet_cpu_limit|regex_replace('m', '')  }} \
-{{ hyperkube_image_repo }}:{{ hyperkube_image_tag}} \
-nsenter --target=1 --mount --wd=. -- \
-./hyperkube kubelet \
-$@
+{{ docker_bin_dir }}/docker run \
+  --net=host \
+  --pid=host \
+  --privileged \
+  --name=kubelet \
+  --restart=on-failure:5 \
+  --memory={{ kubelet_memory_limit|regex_replace('Mi', 'M') }} \
+  --cpu-shares={{ kubelet_cpu_limit|regex_replace('m', '')  }} \
+  -v /etc/cni:/etc/cni:ro \
+  -v /opt/cni:/opt/cni:ro \
+  -v /etc/ssl:/etc/ssl:ro \
+  {% for dir in ssl_ca_dirs -%}
+  -v {{ dir }}:{{ dir }}:ro \
+  {% endfor -%}
+  -v /sys:/sys:ro \
+  -v {{ docker_daemon_graph }}:/var/lib/docker:rw \
+  -v /var/lib/kubelet:/var/lib/kubelet:shared \
+  -v /var/run:/var/run:rw \
+  -v {{kube_config_dir}}:{{kube_config_dir}}:ro \
+  {{ hyperkube_image_repo }}:{{ hyperkube_image_tag}} \
+  ./hyperkube kubelet \
+  $@

--- a/roles/kubernetes/secrets/tasks/gen_certs.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs.yml
@@ -160,6 +160,20 @@
       {%- endif %}
   tags: facts
 
+- name: SSL CA directories | Set SSL CA directories
+  set_fact:
+    ssl_ca_dirs: "[
+      {% if ansible_os_family in ['CoreOS', 'Container Linux by CoreOS'] -%}
+      '/usr/share/ca-certificates',
+      {% elif ansible_os_family == 'RedHat' -%}
+      '/etc/pki/tls',
+      '/etc/pki/ca-trust',
+      {% elif ansible_os_family == 'Debian' -%}
+      '/usr/share/ca-certificates',
+      {% endif -%}
+    ]"
+  tags: facts
+
 - name: Gen_certs | add CA to trusted CA dir
   copy:
     src: "{{ kube_cert_dir }}/ca.pem"


### PR DESCRIPTION
- Docker 1.12 and further don't need nsenter hack. This patch removes
  it.  Also, it bumps the minimal version to 1.12.

Closes #776