### PR TITLE
Specify the version of the credentials to download from Horizon

### DIFF
--- a/contrib/terraform/openstack/README.md
+++ b/contrib/terraform/openstack/README.md
@@ -30,7 +30,7 @@ requirements.
 
 #### OpenStack
 
-Ensure your OpenStack credentials are loaded in environment variables. This can be done by downloading a credentials .rc file from your OpenStack dashboard and sourcing it:
+Ensure your OpenStack **Identity v2** credentials are loaded in environment variables. This can be done by downloading a credentials .rc file from your OpenStack dashboard and sourcing it:
 
 ```
 $ source ~/.stackrc


### PR DESCRIPTION
More recent versions of OpenStack Horizon provide Identity v2 and
Identity v3 versions of the RC file.