### PR TITLE
add skippy stdout callback

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,3 +7,4 @@ host_key_checking=False
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = /tmp
+stdout_callback = skippy


### PR DESCRIPTION
It removes the teal lines when a host is skipped for a task. This makes the output less spammy and much easier to read. Empty TASK blocks are still included in the output, but that's ok.