### PR TITLE
also use kube_api_pwd for root account

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -55,7 +55,7 @@ kube_users:
     pass: "{{kube_api_pwd}}"
     role: admin
   root:
-    pass: "changeme"
+    pass: "{{kube_api_pwd}}"
     role: admin
 
 # Kubernetes cluster name, also will be used as DNS domain


### PR DESCRIPTION
This makes it a bit more secure. Also the password can now be changed with a (inventory) variable (no need to edit all.yml).

I like not to touch `inventory/group_vars/all.yml`, if I can help it, but I haven't found a way to modify the `kube_users` map from within my inventory file (no YAML syntax).

This change also makes the default install a bit more secure, if `kube_api_pwd` was specified.

Possible change: Should the password for `root` be an extra variable instead of `kube_api_pwd`?