### PR TITLE
Switch to ansible_hostname in calico

### DIFF
--- a/roles/network_plugin/calico/templates/calico-node.service.legacy.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.legacy.j2
@@ -7,7 +7,7 @@ Wants=docker.socket
 [Service]
 User=root
 PermissionsStartOnly=true
-{% if inventory_hostname in groups['kube-node'] and peer_with_router|default(false)%}
+{% if inventory_hostname in groups['k8s-cluster'] and peer_with_router|default(false)%}
 ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --as={{ local_as }} --detach=false --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}
 {% else %}
 ExecStart={{ bin_dir }}/calicoctl node --ip={{ip | default(ansible_default_ipv4.address) }} --detach=false --node-image={{ calico_node_image_repo }}:{{ calico_node_image_tag }}

--- a/roles/network_plugin/calico/templates/calico.env.j2
+++ b/roles/network_plugin/calico/templates/calico.env.j2
@@ -7,9 +7,9 @@ CALICO_IP6=""
 {% if calico_network_backend is defined %}
 CALICO_NETWORKING_BACKEND="{{calico_network_backend }}"
 {% endif %}
-{% if inventory_hostname in groups['kube-node'] and peer_with_router|default(false)%}
+{% if inventory_hostname in groups['k8s-cluster'] and peer_with_router|default(false)%}
 CALICO_AS="{{ local_as }}"
 {% endif %}
 CALICO_NO_DEFAULT_POOLS="true"
 CALICO_LIBNETWORK_ENABLED="true"
-CALICO_HOSTNAME="{{ inventory_hostname }}"
+CALICO_HOSTNAME="{{ ansible_hostname }}"

--- a/roles/network_plugin/calico/templates/cni-calico.conf.j2
+++ b/roles/network_plugin/calico/templates/cni-calico.conf.j2
@@ -1,7 +1,7 @@
 {
   "name": "calico-k8s-network",
 {% if not legacy_calicoctl %}
-  "hostname": "{{ inventory_hostname }}",
+  "hostname": "{{ ansible_hostname }}",
 {% endif %}
   "type": "calico",
   "etcd_endpoints": "{{ etcd_access_endpoint }}",


### PR DESCRIPTION
For consistency with kubernetes services we should use the same hostname for calico nodes, which is 'ansible_hostname'.

Hostname inconsistency may become a problem for hybrid workload use cases, for instance running OpenStack + Networking-Calico on top of Kubernetes + Calico:
http://paste.openstack.org/show/596414/

Also fixing missed 'kube-node' in templates, Calico is installed on 'k8s-cluster' roles, not only 'kube-node'.