### PR TITLE
Fixing lint check for ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,6 @@ before_script:
     paths:
       - downloads/
       - $HOME/.cache
-  stage: deploy-gce
   before_script:
     - docker info
     - pip install ansible==2.2.1.0


### PR DESCRIPTION
I'm not sure this was causing any issue with CI, but when running the yaml through the gitlab ci linter, it would fail with ` Error: coreos-calico-sep job: stage parameter should be moderator, unit-tests, deploy-gce-part1, deploy-gce-part2, deploy-gce-special `. 

With the test definition of 
```
coreos-calico-sep:
  stage: deploy-gce-part1
  <<: *job
  <<: *gce
```
We'd define the appropriate stage for the test, but then the gce variables would get merged in. This would change stage from `deploy-gce-part1` to `deploy-gce`. 