### PR TITLE
Bugfix: skip cloud_config on etcd

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -156,7 +156,7 @@
     dest: "{{ kube_config_dir }}/cloud_config"
     group: "{{ kube_cert_group }}"
     mode: 0640
-  when: cloud_provider is defined and cloud_provider == "openstack"
+  when: inventory_hostname in groups['k8s-cluster'] and cloud_provider is defined and cloud_provider == "openstack"
   tags: [cloud-provider, openstack]
 
 - name: Write azure cloud-config
@@ -165,7 +165,7 @@
     dest: "{{ kube_config_dir }}/cloud_config"
     group: "{{ kube_cert_group }}"
     mode: 0640
-  when: cloud_provider is defined and cloud_provider == "azure"
+  when: inventory_hostname in groups['k8s-cluster'] and cloud_provider is defined and cloud_provider == "azure"
   tags: [cloud-provider, azure]
 
 - include: etchosts.yml


### PR DESCRIPTION
I use openstack and I was having trouble on the etcd hosts for bootstrapping. This patch should skip kubelet config on any host which is not in the k8s cluster. Also added the code for the azure cloud config.