### PR TITLE
Bug fix: support OpenStack domain-name property

### DIFF
--- a/roles/kubernetes/preinstall/defaults/main.yml
+++ b/roles/kubernetes/preinstall/defaults/main.yml
@@ -25,6 +25,7 @@ openstack_username: "{{ lookup('env','OS_USERNAME')  }}"
 openstack_password: "{{ lookup('env','OS_PASSWORD')  }}"
 openstack_region: "{{ lookup('env','OS_REGION_NAME')  }}"
 openstack_tenant_id: "{{ lookup('env','OS_TENANT_ID')  }}"
+openstack_domain_name: "{{ lookup('env','OS_USER_DOMAIN_NAME')  }}"
 
 # All clients access each node individually, instead of using a load balancer.
 etcd_multiaccess: true

--- a/roles/kubernetes/preinstall/templates/openstack-cloud-config.j2
+++ b/roles/kubernetes/preinstall/templates/openstack-cloud-config.j2
@@ -4,3 +4,4 @@ username={{ openstack_username }}
 password={{ openstack_password }}
 region={{ openstack_region }}
 tenant-id={{ openstack_tenant_id }}
+domain-name={{ openstack_domain_name }}


### PR DESCRIPTION
The gophercloud update in upstream has added the requirement for the `domain-name` property. This value is exported by my openstack RC so the ansible script should just pick it up.