### PR TITLE
Using the command module instead of raw

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -69,7 +69,7 @@
   when: (not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]) and (docker_package_info.pkgs|length > 0)
 
 - name: check minimum docker version for docker_dns mode. You need at least docker version >= 1.12 for resolvconf_mode=docker_dns
-  raw: docker version -f "{{ '{{' }}.Client.Version{{ '}}' }}"
+  command: "docker version -f '{{ '{{' }}.Client.Version{{ '}}' }}'"
   register: docker_version
   failed_when: docker_version.stdout|version_compare('1.12', '<')
   changed_when: false


### PR DESCRIPTION
Using the command module instead of raw.
Also fixed the syntax.