### PR TITLE
Explicitly set config path for DNSMasq

### DIFF
--- a/roles/dnsmasq/templates/dnsmasq-ds.yml
+++ b/roles/dnsmasq/templates/dnsmasq-ds.yml
@@ -20,8 +20,8 @@ spec:
             - dnsmasq
           args:
             - -k
-            - "-7"
-            - /etc/dnsmasq.d
+            - -C
+            - /etc/dnsmasq.d/01-kube-dns.conf
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
When DNSMasq is configured to read its settings
from a folder ('-7' or '--conf-dir' option) it only
checks that the directory exists and doesn't fail if
it's empty. It could lead to a situation when DNSMasq
is running and handles requests, but not properly
configured, so some of queries can't be resolved.