### PR TITLE
Disable idempotency for ubuntu-weave-sep

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -264,7 +264,7 @@ before_script:
   CLOUD_IMAGE: ubuntu-1604-xenial
   CLOUD_REGION: us-central1-b
   CLUSTER_MODE: separate
-  IDEMPOT_CHECK: "true"
+  IDEMPOT_CHECK: "false"
 
 .centos7_calico_ha_variables: &centos7_calico_ha_variables
 # stage: deploy-gce-special


### PR DESCRIPTION
CI is failing 40% of the time due to errors in reset.
Let's disable idempotency check per-patch until we fix it.

Fixes #953