### PR TITLE
Update playbooks to support new netchecker

### DIFF
--- a/docs/netcheck.md
+++ b/docs/netcheck.md
@@ -2,7 +2,7 @@ Network Checker Application
 ===========================
 
 With the ``deploy_netchecker`` var enabled (defaults to false), Kargo deploys a
-Network Checker Application from the 3rd side `l23network/mcp-netchecker` docker
+Network Checker Application from the 3rd side `l23network/k8s-netchecker` docker
 images. It consists of the server and agents trying to reach the server by usual
 for Kubernetes applications network connectivity meanings. Therefore, this
 automagically verifies a pod to pod connectivity via the cluster IP and checks
@@ -25,8 +25,8 @@ There are related application specifc variables:
 netchecker_port: 31081
 agent_report_interval: 15
 netcheck_namespace: default
-agent_img: "quay.io/l23network/mcp-netchecker-agent:v0.1"
-server_img: "quay.io/l23network/mcp-netchecker-server:v0.1"
+agent_img: "quay.io/l23network/k8s-netchecker-agent:v1.0"
+server_img: "quay.io/l23network/k8s-netchecker-server:v1.0"
 ```
 
 Note that the application verifies DNS resolve for FQDNs comprising only the

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -59,11 +59,9 @@ hyperkube_image_repo: "quay.io/coreos/hyperkube"
 hyperkube_image_tag: "{{ kube_version }}_coreos.0"
 pod_infra_image_repo: "gcr.io/google_containers/pause-amd64"
 pod_infra_image_tag: "{{ pod_infra_version }}"
-netcheck_tag: v0.1
-netcheck_kubectl_tag: v0.18.0-120-gaeb4ac55ad12b1-dirty
-netcheck_agent_img_repo: "quay.io/l23network/mcp-netchecker-agent"
-netcheck_server_img_repo: "quay.io/l23network/mcp-netchecker-server"
-netcheck_kubectl_img_repo: "gcr.io/google_containers/kubectl"
+netcheck_tag: "v1.0"
+netcheck_agent_img_repo: "quay.io/l23network/k8s-netchecker-agent"
+netcheck_server_img_repo: "quay.io/l23network/k8s-netchecker-server"
 weave_kube_image_repo: "weaveworks/weave-kube"
 weave_kube_image_tag: "{{ weave_version }}"
 weave_npc_image_repo: "weaveworks/weave-npc"
@@ -95,12 +93,6 @@ downloads:
     repo: "{{ netcheck_agent_img_repo }}"
     tag: "{{ netcheck_tag }}"
     sha256: "{{ netcheck_agent_digest_checksum|default(None) }}"
-    enabled: "{{ deploy_netchecker|bool }}"
-  netcheck_kubectl:
-    container: true
-    repo: "{{ netcheck_kubectl_img_repo }}"
-    tag: "{{ netcheck_kubectl_tag }}"
-    sha256: "{{ netcheck_kubectl_digest_checksum|default(None) }}"
     enabled: "{{ deploy_netchecker|bool }}"
   etcd:
     version: "{{etcd_version}}"

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -31,7 +31,6 @@ agent_report_interval: 15
 netcheck_namespace: default
 agent_img: "{{ netcheck_agent_img_repo }}:{{ netcheck_tag }}"
 server_img: "{{ netcheck_server_img_repo }}:{{ netcheck_tag }}"
-kubectl_image: "{{ netcheck_kubectl_img_repo }}:{{ netcheck_kubectl_tag }}"
 
 # Limits for netchecker apps
 netchecker_agent_cpu_limit: 30m
@@ -42,10 +41,6 @@ netchecker_server_cpu_limit: 100m
 netchecker_server_memory_limit: 256M
 netchecker_server_cpu_requests: 50m
 netchecker_server_memory_requests: 128M
-netchecker_kubectl_cpu_limit: 30m
-netchecker_kubectl_memory_limit: 128M
-netchecker_kubectl_cpu_requests: 15m
-netchecker_kubectl_memory_requests: 64M
 
 # SSL
 etcd_cert_dir: "/etc/ssl/etcd/ssl"

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml
@@ -20,8 +20,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: REPORT_INTERVAL
-              value: '{{ agent_report_interval }}'
+          args:
+            - "-v=5"
+            - "-alsologtostderr=true"
+            - "-serverendpoint=netchecker-service:8081"
+            - "-reportinterval={{ agent_report_interval }}"
           imagePullPolicy: {{ k8s_image_pull_policy }}
           resources:
             limits:

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.yml
@@ -21,8 +21,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: REPORT_INTERVAL
-              value: '{{ agent_report_interval }}'
+          args:
+            - "-v=5"
+            - "-alsologtostderr=true"
+            - "-serverendpoint=netchecker-service:8081"
+            - "-reportinterval={{ agent_report_interval }}"
           imagePullPolicy: {{ k8s_image_pull_policy }}
           resources:
             limits:

--- a/roles/kubernetes-apps/ansible/templates/netchecker-server-pod.yml
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-server-pod.yml
@@ -21,15 +21,8 @@ spec:
       ports:
         - containerPort: 8081
           hostPort: 8081
-    - name: kubectl-proxy
-      image: "{{ kubectl_image }}"
-      imagePullPolicy: {{ k8s_image_pull_policy }}
-      resources:
-        limits:
-          cpu: {{ netchecker_kubectl_cpu_limit }}
-          memory: {{ netchecker_kubectl_memory_limit }}
-        requests:
-          cpu: {{ netchecker_kubectl_cpu_requests }}
-          memory: {{ netchecker_kubectl_memory_requests }}
       args:
-        - proxy
+        - "-v=5"
+        - "-logtostderr"
+        - "-kubeproxyinit"
+        - "-endpoint=0.0.0.0:8081"

--- a/roles/kubernetes-apps/meta/main.yaml
+++ b/roles/kubernetes-apps/meta/main.yaml
@@ -12,9 +12,5 @@ dependencies:
     file: "{{ downloads.netcheck_agent }}"
     when: deploy_netchecker
     tags: [download, netchecker]
-  - role: download
-    file: "{{ downloads.netcheck_kubectl }}"
-    when: deploy_netchecker
-    tags: [download, netchecker]
   - {role: kubernetes-apps/ansible, tags: apps}
   - {role: kubernetes-apps/kpm, tags: [apps, kpm]}

--- a/roles/kubernetes/node/meta/main.yml
+++ b/roles/kubernetes/node/meta/main.yml
@@ -23,10 +23,6 @@ dependencies:
     when: deploy_netchecker
     tags: [download, netchecker]
   - role: download
-    file: "{{ downloads.netcheck_kubectl }}"
-    when: deploy_netchecker
-    tags: [download, netchecker]
-  - role: download
     file: "{{ downloads.kubednsmasq }}"
     tags: [download, dnsmasq]
   - role: download


### PR DESCRIPTION
Netchecker is rewritten in Go lang with some new args instead of env variables. Also netchecker-server no longer requires kubectl container. Updating playbooks accordingly.