### PR TITLE
handle both 'ansible_host' and 'ansible_ssh_host' in bastion configration

### DIFF
--- a/roles/bastion-ssh-config/templates/ssh-bastion.conf
+++ b/roles/bastion-ssh-config/templates/ssh-bastion.conf
@@ -4,7 +4,7 @@
 
 {% for h in groups['all'] %}
 {% if h != 'bastion' %}
-{% if vars.update({'hosts': vars['hosts'] + ' ' + hostvars[h]['ansible_ssh_host']}) %}{% endif %}
+{% if vars.update({'hosts': vars['hosts'] + ' ' + (hostvars[h].get('ansible_ssh_host') or hostvars[h]['ansible_host'])}) %}{% endif %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
`absible_ssh_host` is deprecated in Ansible 2.0 and at least `contrib/inventory_builder/inventory.py` uses `ansible_host` instead.