### PR TITLE
remove deprecated ubuntu-bootstrap.yml script

### DIFF
--- a/ubuntu-bootstrap.yml
+++ b/ubuntu-bootstrap.yml
@@ -1,5 +1,0 @@
----
-- hosts: all
-  gather_facts: False
-  roles:
-    - ubuntu-bootstrap


### PR DESCRIPTION
I believe proper way to do bootstrapping on Ubuntu is to set `booststrap_os: ubuntu` in the inventory and run something like:

```
ansible-playbook -i inventory/inventory.cfg -b cluster.yml --tags bootstrap-os
```