### PR TITLE
Prevent dynamic port allocation in nodePort range

### DIFF
--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -29,3 +29,7 @@ nginx_image_repo: nginx
 nginx_image_tag: 1.11.4-alpine
 
 etcd_config_dir: /etc/ssl/etcd
+
+# A port range to reserve for services with NodePort visibility.
+# Inclusive at both ends of the range.
+kube_apiserver_node_port_range: "30000-32767"

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -21,6 +21,16 @@
   notify: restart kubelet
   tags: kubelet
 
+- name: Ensure nodePort range is reserved
+  sysctl:
+    name: net.ipv4.ip_local_reserved_ports
+    value: "{{ kube_apiserver_node_port_range }}"
+    sysctl_set: yes
+    state: present
+    reload: yes
+  when: kube_apiserver_node_port_range is defined
+  tags: kube-proxy
+
 - name: Write proxy manifest
   template:
     src: manifests/kube-proxy.manifest.j2


### PR DESCRIPTION
kube_apiserver_node_port_range should be accessible only
to kube-proxy and not be taken by a dynamic port allocation.

Potentially temporary if https://github.com/kubernetes/kubernetes/issues/40920
gets fixed.