### PR TITLE
Add .swp .swo .swn to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ temp
 *.pyo
 *.tfstate
 *.tfstate.backup
+**/*.sw[pon]
 /ssh-bastion.conf


### PR DESCRIPTION
According to http://vimdoc.sourceforge.net/htmldoc/recover.html vim
creates .swo .swn .swp files. This patch adds them to .gitignore in all
directories recursively

Closes: #973