### PR TITLE
set "check_mode: on" for read-only "shell" steps that registers result

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -18,6 +18,7 @@
   register: need_pip
   failed_when: false
   changed_when: false
+  check_mode: no
   when: (need_bootstrap | failed)
   tags: facts
 
@@ -45,6 +46,7 @@
 - name: Check configured hostname
   shell: hostname
   register: configured_hostname
+  check_mode: no
 
 - name: Assign inventory name to unconfigured hostnames
   shell: sh -c "echo \"{{inventory_hostname}}\" > /etc/hostname; hostname \"{{inventory_hostname}}\""

--- a/roles/docker/tasks/set_facts_dns.yml
+++ b/roles/docker/tasks/set_facts_dns.yml
@@ -32,11 +32,13 @@
   shell: grep "^nameserver" /etc/resolv.conf | sed 's/^nameserver\s*//'
   changed_when: False
   register: system_nameservers
+  check_mode: no
 
 - name: check system search domains
   shell: grep "^search" /etc/resolv.conf | sed 's/^search\s*//'
   changed_when: False
   register: system_search_domains
+  check_mode: no
 
 - name: add system nameservers to docker options
   set_fact:

--- a/roles/download/tasks/set_docker_image_facts.yml
+++ b/roles/download/tasks/set_docker_image_facts.yml
@@ -12,6 +12,7 @@
     {{ docker_bin_dir }}/docker images -q | xargs {{ docker_bin_dir }}/docker inspect -f "{{ '{{' }} .RepoTags {{ '}}' }},{{ '{{' }} .RepoDigests {{ '}}' }}"
   register: docker_images_raw
   failed_when: false
+  check_mode: no
   when: not download_always_pull|bool
 
 - set_fact: docker_images="{{docker_images_raw.stdout|regex_replace('\[|\]|\\n]','')|regex_replace('\s',',')}}"

--- a/roles/etcd/tasks/configure.yml
+++ b/roles/etcd/tasks/configure.yml
@@ -4,6 +4,7 @@
   register: etcd_member_in_cluster
   failed_when: false
   changed_when: false
+  check_mode: no
   when: is_etcd_master
   tags: facts
 

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -87,6 +87,7 @@
   args:
     executable: /bin/bash
   register: etcd_master_cert_data
+  check_mode: no
   delegate_to: "{{groups['etcd'][0]}}"
   when: inventory_hostname in groups['etcd'] and sync_certs|default(false) and
         inventory_hostname != groups['etcd'][0]
@@ -97,6 +98,7 @@
   args:
     executable: /bin/bash
   register: etcd_node_cert_data
+  check_mode: no
   delegate_to: "{{groups['etcd'][0]}}"
   when: (('calico-rr' in groups and inventory_hostname in groups['calico-rr']) or
         inventory_hostname in groups['k8s-cluster']) and

--- a/roles/etcd/tasks/set_cluster_health.yml
+++ b/roles/etcd/tasks/set_cluster_health.yml
@@ -4,5 +4,6 @@
   register: etcd_cluster_is_healthy
   failed_when: false
   changed_when: false
+  check_mode: no
   when: is_etcd_master
   tags: facts

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -108,6 +108,7 @@
   shell: rpm -qa | grep epel-release || rpm -ivh {{ epel_rpm_download_url }}
   when: ansible_distribution in ["CentOS","RedHat"]
   changed_when: False
+  check_mode: no
   tags: bootstrap-os
 
 - name: Install packages requirements

--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -4,6 +4,7 @@
   register: resolvconf
   failed_when: false
   changed_when: false
+  check_mode: no
 
 - set_fact:
     resolvconf: >-

--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -81,6 +81,7 @@
   args:
     executable: /bin/bash
   register: master_cert_data
+  check_mode: no
   delegate_to: "{{groups['kube-master'][0]}}"
   when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]
@@ -90,6 +91,7 @@
   args:
     executable: /bin/bash
   register: node_cert_data
+  check_mode: no
   delegate_to: "{{groups['kube-master'][0]}}"
   when: inventory_hostname in groups['kube-node'] and
         sync_certs|default(false) and
@@ -115,6 +117,7 @@
 - name: Gen_certs | Unpack certs on masters
   shell: "base64 -d < {{ cert_tempfile.stdout }} | tar xz -C {{ kube_cert_dir }}"
   changed_when: false
+  check_mode: no
   when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]
   notify: set secret_changed
@@ -131,6 +134,7 @@
   args:
     executable: /bin/bash
   changed_when: false
+  check_mode: no
   when: inventory_hostname in groups['kube-node'] and
         sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]

--- a/roles/kubernetes/secrets/tasks/gen_tokens.yml
+++ b/roles/kubernetes/secrets/tasks/gen_tokens.yml
@@ -40,12 +40,14 @@
   shell: "(find {{ kube_token_dir }} -maxdepth 1 -type f)"
   register: tokens_list
   changed_when: false
+  check_mode: no
   delegate_to: "{{groups['kube-master'][0]}}"
   when: sync_tokens|default(false)
 
 - name: Gen_tokens | Gather tokens
   shell: "tar cfz - {{ tokens_list.stdout_lines | join(' ') }} | base64 --wrap=0"
   register: tokens_data
+  check_mode: no
   delegate_to: "{{groups['kube-master'][0]}}"
   run_once: true
   when: sync_tokens|default(false)

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -42,6 +42,7 @@
   shell: cat /run/flannel/subnet.env | awk -F'=' '$1 == "FLANNEL_SUBNET" {print $2}'
   register: flannel_subnet_output
   changed_when: false
+  check_mode: no
 
 - set_fact:
     flannel_subnet: "{{ flannel_subnet_output.stdout }}"
@@ -51,6 +52,7 @@
   shell: cat /run/flannel/subnet.env | awk -F'=' '$1 == "FLANNEL_MTU" {print $2}'
   register: flannel_mtu_output
   changed_when: false
+  check_mode: no
 
 - set_fact:
     flannel_mtu: "{{ flannel_mtu_output.stdout }}"

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -38,6 +38,7 @@
 
 - name: reset | gather mounted kubelet dirs
   shell: mount | grep /var/lib/kubelet | awk '{print $3}' | tac
+  check_mode: no
   register: mounted_dirs
 
 - name: reset | unmount kubelet dirs


### PR DESCRIPTION
"shell" step doesn't support check mode, which currently leads to failures,
when Ansible is being run in check mode (because Ansible doesn't run command,
assuming that command might have effect, and no "rc" or "output" is registered).

Setting "check_mode: on" allows to run those "shell" commands in check mode
(which is safe, because those shell commands doesn't have side effects).