### PR TITLE
Also add the system nameservers to upstream servers in dnsmasq

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -11,6 +11,20 @@
     state: directory
   tags: bootstrap-os
 
+- name: check system nameservers
+  shell: awk '/^nameserver/ {print $NF}' /etc/resolv.conf
+  changed_when: False
+  register: system_nameservers
+
+- name: init system_and_upstream_dns_servers
+  set_fact:
+    system_and_upstream_dns_servers: "{{ upstream_dns_servers|default([]) }}"
+
+- name: combine upstream_dns_servers and system nameservers (only for docker_dns)
+  set_fact:
+    system_and_upstream_dns_servers: "{{ system_and_upstream_dns_servers | union(system_nameservers.stdout_lines) | unique }}"
+  when: system_nameservers.stdout != "" and resolvconf_mode != 'host_resolvconf'
+
 - name: Write dnsmasq configuration
   template:
     src: 01-kube-dns.conf.j2

--- a/roles/dnsmasq/templates/01-kube-dns.conf.j2
+++ b/roles/dnsmasq/templates/01-kube-dns.conf.j2
@@ -11,20 +11,19 @@ server=/{{ dns_domain }}/{{ skydns_server }}
 local=/{{ bogus_domains }}
 
 #Set upstream dns servers
-{% if upstream_dns_servers is defined %}
-{% for srv in upstream_dns_servers %}
+{% if system_and_upstream_dns_servers|length > 0 %}
+{% for srv in system_and_upstream_dns_servers %}
 server={{ srv }}
 {% endfor %}
-no-resolv
 {% elif resolvconf_mode == 'host_resolvconf' %}
 {# The default resolver is only needed when the hosts resolv.conf was modified by us. If it was not modified, we can rely on dnsmasq to reuse the systems resolv.conf #}
 server={{ default_resolver }}
-no-resolv
 {% endif %}
 
 {% if kube_log_level == '4' %}
 log-queries
 {% endif %}
+no-resolv
 bogus-priv
 no-negcache
 cache-size={{ cache_size }}


### PR DESCRIPTION
Also make no-resolv unconditional again. Otherwise, we may end up in
a resolver loop. The resolver loop was the cause for the piling up
parallel queries.