### PR TITLE
Re-tune ETCD performance params

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -7,6 +7,11 @@ etcd_cert_group: root
 
 etcd_script_dir: "{{ bin_dir }}/etcd-scripts"
 
+etcd_heartbeat_interval: "250"
+etcd_election_timeout: "5000"
+
 # Limits
 etcd_memory_limit: 512M
-etcd_cpu_limit: 300m
+
+# Uncomment to set CPU share for etcd
+#etcd_cpu_limit: 300m

--- a/roles/etcd/templates/etcd-docker.service.j2
+++ b/roles/etcd/templates/etcd-docker.service.j2
@@ -14,7 +14,12 @@ ExecStart={{ docker_bin_dir }}/docker run --restart=on-failure:5 \
 -v /etc/ssl/certs:/etc/ssl/certs:ro \
 -v {{ etcd_cert_dir }}:{{ etcd_cert_dir }}:ro \
 -v /var/lib/etcd:/var/lib/etcd:rw \
---memory={{ etcd_memory_limit|regex_replace('Mi', 'M') }} --cpu-shares={{ etcd_cpu_limit|regex_replace('m', '') }} \
+{% if etcd_memory_limit is defined %}
+--memory={{ etcd_memory_limit|regex_replace('Mi', 'M') }} \
+{% endif %}
+{% if etcd_cpu_limit is defined %}
+--cpu-shares={{ etcd_cpu_limit|regex_replace('m', '') }} \
+{% endif %}
 --name={{ etcd_member_name | default("etcd") }} \
 {{ etcd_image_repo }}:{{ etcd_image_tag }} \
 {% if etcd_after_v3 %}

--- a/roles/etcd/templates/etcd.j2
+++ b/roles/etcd/templates/etcd.j2
@@ -4,7 +4,8 @@ ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_peer_url }}
 ETCD_INITIAL_CLUSTER_STATE={% if etcd_cluster_is_healthy.rc != 0 | bool %}new{% else %}existing{% endif %}
 
 ETCD_LISTEN_CLIENT_URLS=https://{{ etcd_address }}:2379,https://127.0.0.1:2379
-ETCD_ELECTION_TIMEOUT=10000
+ETCD_ELECTION_TIMEOUT={{ etcd_election_timeout }}
+ETCD_HEARTBEAT_INTERVAL={{ etcd_heartbeat_interval }}
 ETCD_INITIAL_CLUSTER_TOKEN=k8s_etcd
 ETCD_LISTEN_PEER_URLS=https://{{ etcd_address }}:2380
 ETCD_NAME={{ etcd_member_name }}


### PR DESCRIPTION
Reduce election timeout to 5000ms (was 10000ms)
Raise heartbeat interval to 250ms (was 100ms)
Remove etcd cpu share (was 300)
Make etcd_cpu_limit and etcd_memory_limit optional.