### PR TITLE
Host mount /dev for kubelet

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -7,6 +7,7 @@
   --restart=on-failure:5 \
   --memory={{ kubelet_memory_limit|regex_replace('Mi', 'M') }} \
   --cpu-shares={{ kubelet_cpu_limit|regex_replace('m', '')  }} \
+  -v /dev:/dev:rw \
   -v /etc/cni:/etc/cni:ro \
   -v /opt/cni:/opt/cni:ro \
   -v /etc/ssl:/etc/ssl:ro \


### PR DESCRIPTION
Now that the nsenter hack was removed from kubelet, block devices in /dev are not propagated into the kubelet container when disks are attached to the VM after the container was started. This results in persistent volumes not working anymore.

There is an issue in docker for this: https://github.com/docker/docker/issues/16160