### PR TITLE
Change docker save compress level to 1

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -3,9 +3,9 @@ local_release_dir: /tmp
 
 # if this is set to true will only download files once. Doesn't work
 # on Container Linux by CoreOS unless the download_localhost is true and localhost
-# is running another OS type. Default compress level is 9 (best).
+# is running another OS type. Default compress level is 1 (fastest).
 download_run_once: False
-download_compress: 9
+download_compress: 1
 
 # if this is set to true, uses the localhost for download_run_once mode
 # (requires docker and sudo to access docker). You may want this option for


### PR DESCRIPTION
Faster gzip improves CI deploy times by at least 2 mins.

Fixes #982