### PR TITLE
Fix upgrade for all daemonset type resources

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -8,6 +8,18 @@
   register: manifests
   when: inventory_hostname == groups['kube-master'][0]
 
+#FIXME: remove if kubernetes/features#124 is implemented
+- name: Kubernetes Apps | Purge old Netchecker daemonsets
+  kube:
+    name: "{{item.item.name}}"
+    namespace: "{{netcheck_namespace}}"
+    kubectl: "{{bin_dir}}/kubectl"
+    resource: "{{item.item.type}}"
+    filename: "{{kube_config_dir}}/{{item.item.file}}"
+    state: absent
+  with_items: "{{ manifests.results }}"
+  when: inventory_hostname == groups['kube-master'][0] and item.item.type == "ds" and item.changed
+
 - name: Kubernetes Apps | Start Netchecker Resources
   kube:
     name: "{{item.item.name}}"

--- a/roles/kubernetes-apps/efk/fluentd/tasks/main.yml
+++ b/roles/kubernetes-apps/efk/fluentd/tasks/main.yml
@@ -1,9 +1,20 @@
 ---
 - name: "Fluentd | Write fluentd daemonset"
-  template: 
+  template:
     src: fluentd-ds.yml.j2
     dest: "{{ kube_config_dir }}/fluentd-ds.yaml"
   register: fluentd_ds_manifest
+
+#FIXME: remove if kubernetes/features#124 is implemented
+- name: "Fluentd | Purge old fluentd daemonset"
+  kube:
+    filename: "{{kube_config_dir}}/fluentd-ds.yaml"
+    kubectl: "{{bin_dir}}/kubectl"
+    name: "fluentd-es-v{{ fluentd_version }}"
+    namespace: "{{system_namespace}}"
+    resource: "ds"
+    state: absent
+  when: inventory_hostname == groups['kube-master'][0] and fluentd_ds_manifest.changed
 
 - name: "Fluentd | Create fluentd daemonset"
   kube:

--- a/roles/kubernetes-apps/network_plugin/canal/tasks/main.yaml
+++ b/roles/kubernetes-apps/network_plugin/canal/tasks/main.yaml
@@ -7,6 +7,18 @@
     resource: "configmap"
     namespace: "{{system_namespace}}"
 
+#FIXME: remove if kubernetes/features#124 is implemented
+- name: Purge old flannel and canal-node
+  run_once: true
+  kube:
+    name: "canal-node"
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ kube_config_dir }}/canal-node.yml"
+    resource: "ds"
+    namespace: "{{system_namespace}}"
+    state: absent
+  when: inventory_hostname == groups['kube-master'][0] and canal_node_manifest.changed
+
 - name: Start flannel and calico-node
   run_once: true
   kube:
@@ -15,3 +27,6 @@
     filename: "{{kube_config_dir}}/canal-node.yaml"
     resource: "ds"
     namespace: "{{system_namespace}}"
+    state: "{{ item | ternary('latest','present') }}"
+  with_items: "{{ canal_node_manifest.changed }}"
+

--- a/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
+++ b/roles/kubernetes-apps/network_plugin/weave/tasks/main.yml
@@ -1,3 +1,16 @@
+#FIXME: remove if kubernetes/features#124 is implemented
+- name: Weave | Purge old weave daemonset
+  run_once: true
+  kube:
+    name: "weave-net"
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ kube_config_dir }}/weave-net.yml"
+    resource: "ds"
+    namespace: "{{system_namespace}}"
+    state: absent
+  when: inventory_hostname == groups['kube-master'][0] and weave_manifest.changed
+
+
 - name: Weave | Start Resources
   run_once: true
   kube:

--- a/roles/network_plugin/canal/tasks/main.yml
+++ b/roles/network_plugin/canal/tasks/main.yml
@@ -41,6 +41,7 @@
   template:
     src: canal-node.yml.j2
     dest: "{{kube_config_dir}}/canal-node.yaml"
+  register: canal_node_manifest
 
 - name: Canal | Copy cni plugins from hyperkube
   command: "{{ docker_bin_dir }}/docker run --rm -v /opt/cni/bin:/cnibindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /usr/bin/rsync -a /opt/cni/bin/ /cnibindir/"


### PR DESCRIPTION
Daemonsets cannot be simply upgraded through a single API call,
regardless of any kubectl documentation. The resource must be
purged and then recreated in order to make any changes.