### PR TITLE
Lower weave RAM settings.

### DIFF
--- a/roles/network_plugin/weave/defaults/main.yml
+++ b/roles/network_plugin/weave/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Limits
-weave_memory_limit: 500M
+weave_memory_limit: 400M
 weave_cpu_limit: 30m
-weave_memory_requests: 300M
+weave_memory_requests: 200M
 weave_cpu_requests: 10m


### PR DESCRIPTION
- Since Weave 1.8.x was rewritten in Golang we may decrease RAM settings
  to continue using g1-small for CI