### PR TITLE
removed explicit role for efk in cluster.yml

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -63,4 +63,3 @@
   any_errors_fatal: true
   roles:
     - { role: kubernetes-apps, tags: apps }
-    - { role: kubernetes-apps/efk, tags: [ apps, efk ] }


### PR DESCRIPTION
Patch for #1000 wherein "efk" related tasks were executing inadvertently

Tested with `efk_enable: false`