### PR TITLE
use ansible sysctl module for config ip forwarding

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -140,14 +140,10 @@
   tags: bootstrap-os
 
 - name: Enable ip forwarding
-  lineinfile:
-    dest: /etc/sysctl.d/99-sysctl.conf
-    regexp: '^net.ipv4.ip_forward='
-    line: 'net.ipv4.ip_forward=1'
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: 1
     state: present
-    create: yes
-    backup: yes
-    validate: 'sysctl -f %s'
   tags: bootstrap-os
 
 - name: Write openstack cloud-config

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -139,8 +139,25 @@
   when: disable_ipv6_dns and not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"]
   tags: bootstrap-os
 
+- name: set default sysctl file path
+  set_fact:
+    sysctl_file_path: "/etc/sysctl.d/99-sysctl.conf"
+  tags: bootstrap-os
+
+- name: Stat sysctl file configuration
+  stat: path={{sysctl_file_path}}
+  register: sysctl_file_stat
+  tags: bootstrap-os
+
+- name: Change sysctl file path to link source if linked
+  set_fact:
+    sysctl_file_path: "{{sysctl_file_stat.stat.lnk_source}}"
+  when: sysctl_file_stat.stat.islnk is defined and sysctl_file_stat.stat.islnk
+  tags: bootstrap-os
+
 - name: Enable ip forwarding
   sysctl:
+    sysctl_file: "{{sysctl_file_path}}"
     name: net.ipv4.ip_forward
     value: 1
     state: present


### PR DESCRIPTION
on centos 7.2, /etc/systctl.d/99-sysctl.conf is symlinked to /etc/sysctl.conf and ansible "lineinfile" module cannot handle symlinks.
