### PR TITLE
Allow kubelet to load kernel modules

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -92,6 +92,10 @@ Stack](https://github.com/kubernetes-incubator/kargo/blob/master/docs/dns-stack.
   ``--insecure-registry=myregistry.mydomain:5000``
 * *http_proxy/https_proxy/no_proxy* - Proxy variables for deploying behind a
   proxy
+* *kubelet_load_modules* - For some things, kubelet needs to load kernel modules.  For example,
+  dynamic kernel services are needed for mounting persistent volumes into containers.  These may not be
+  loaded by preinstall kubernetes processes.  For example, ceph and rbd backed volumes.  Set this variable to
+  true to let kubelet load kernel modules.
 
 #### User accounts
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -48,6 +48,14 @@ kube_log_level: 2
 # 1.5 default behavior. The flag is actually only added if the used kubernetes version is >= 1.5
 kube_api_anonymous_auth: false
 
+#
+# For some things, kubelet needs to load kernel modules.  For example, dynamic kernel services are needed
+# for mounting persistent volumes into containers.  These may not be loaded by preinstall kubernetes
+# processes.  For example, ceph and rbd backed volumes.  Uncomment to allow kubelet to load kernel
+# modules.
+#
+#kubelet_load_modules: true
+
 # Users to create for basic auth in Kubernetes API via HTTP
 kube_api_pwd: "changeme"
 kube_users:

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -51,10 +51,10 @@ kube_api_anonymous_auth: false
 #
 # For some things, kubelet needs to load kernel modules.  For example, dynamic kernel services are needed
 # for mounting persistent volumes into containers.  These may not be loaded by preinstall kubernetes
-# processes.  For example, ceph and rbd backed volumes.  Uncomment to allow kubelet to load kernel
+# processes.  For example, ceph and rbd backed volumes.  Set to true to allow kubelet to load kernel
 # modules.
 #
-#kubelet_load_modules: true
+kubelet_load_modules: false
 
 # Users to create for basic auth in Kubernetes API via HTTP
 kube_api_pwd: "changeme"

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -33,3 +33,5 @@ etcd_config_dir: /etc/ssl/etcd
 # A port range to reserve for services with NodePort visibility.
 # Inclusive at both ends of the range.
 kube_apiserver_node_port_range: "30000-32767"
+
+kubelet_load_modules: false

--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -14,6 +14,9 @@
   {% for dir in ssl_ca_dirs -%}
   -v {{ dir }}:{{ dir }}:ro \
   {% endfor -%}
+  {% if kubelet_load_modules is defined and kubelet_load_modules == true -%}
+  -v /lib/modules:/lib/modules:ro \
+  {% endif -%}
   -v /sys:/sys:ro \
   -v {{ docker_daemon_graph }}:/var/lib/docker:rw \
   -v /var/lib/kubelet:/var/lib/kubelet:shared \

--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -14,7 +14,7 @@
   {% for dir in ssl_ca_dirs -%}
   -v {{ dir }}:{{ dir }}:ro \
   {% endfor -%}
-  {% if kubelet_load_modules is defined and kubelet_load_modules == true -%}
+  {% if kubelet_load_modules -%}
   -v /lib/modules:/lib/modules:ro \
   {% endif -%}
   -v /sys:/sys:ro \


### PR DESCRIPTION
Due to the nsenter and other reworks, it appears that
kubelet lost the ability to load kernel modules.  This
puts that back by adding the lib/modules mount to kubelet.

The new variable kubelet_load_modules can be set to true
to enable this item.  It is OFF by default.