### PR TITLE
Align LB defaults with the HA docs

### DIFF
--- a/docs/ha-mode.md
+++ b/docs/ha-mode.md
@@ -15,8 +15,7 @@ The `etcd_access_endpoint` fact provides an access pattern for clients. And the
 `etcd_multiaccess` (defaults to `True`) group var controlls that behavior.
 It makes deployed components to access the etcd cluster members
 directly: `http://ip1:2379, http://ip2:2379,...`. This mode assumes the clients
-do a loadbalancing and handle HA for connections. Note, a pod definition of a
-flannel networking plugin always uses a single `--etcd-server` endpoint!
+do a loadbalancing and handle HA for connections.
 
 
 Kube-apiserver

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -103,7 +103,7 @@ etcd_multiaccess: true
 
 # Assume there are no internal loadbalancers for apiservers exist and listen on
 # kube_apiserver_port (default 443)
-loadbalancer_apiserver_localhost: true
+loadbalancer_apiserver_localhost: false
 
 # Choose network plugin (calico, canal, weave or flannel)
 # Can also be set to 'cloud', which lets the cloud provider setup appropriate routing


### PR DESCRIPTION
Do not deploy nginx proxy for API servers internal LB
by default

Complements https://github.com/kubernetes-incubator/kargo/pull/1010
Releted https://github.com/kubernetes-incubator/kargo/issues/1003

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>