### PR TITLE
Replace always_run with check_mode

### DIFF
--- a/roles/kubernetes/preinstall/tasks/gitinfos.yml
+++ b/roles/kubernetes/preinstall/tasks/gitinfos.yml
@@ -10,7 +10,7 @@
 - name: 'GIT | generate git informations'
   local_action: command {{ role_path }}/gen-gitinfos.sh global
   register: gitinfo
-  always_run: yes
+  check_mode: no
 
 - name: 'GIT | copy ansible information'
   template:
@@ -21,7 +21,7 @@
 - name: 'GIT | generate diff file'
   local_action: command {{ role_path }}/gen-gitinfos.sh diff
   register: gitdiff
-  always_run: yes
+  check_mode: no
 
 - name: 'GIT | copy git diff file'
   copy:


### PR DESCRIPTION
always_run was deprecated in Ansible 2.2 and will be removed in 2.4
ansible logs contain "[DEPRECATION WARNING]: always_run is deprecated.
Use check_mode = no instead". This patch fix deprecation.