### PR TITLE
Install pip on Ubuntu

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-ubuntu.yml
@@ -10,11 +10,12 @@
     - pip
   tags: facts
 
-- name: Bootstrap | Install python 2.x
-  raw: >
+- name: Bootstrap | Install python 2.x and pip
+  raw:
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal pip
-  when: need_bootstrap | failed
+    DEBIAN_FRONTEND=noninteractive apt-get install -y python-minimal python-pip
+  when:
+    "{{ need_bootstrap.results | map(attribute='rc') | sort | last | bool }}"
 
 - set_fact:
     ansible_python_interpreter: "/usr/bin/python"


### PR DESCRIPTION
- Refactor 'Check if bootstrap is needed' as ansible loop. This allows
  to add new elements easily without refactoring. Add pip to the list.
- Refactor 'Install python 2.x' task to run once if any of rc
  codes != 0. Actually, need_bootstrap is array of hashes, so map will
  allow to get single array of rc statuses. So if status is not zero it
  will be sorted and the last element will be get, converted to bool.

Closes: #961
Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>