### PR TITLE
Add timings to RECAP output.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,3 +9,4 @@ fact_caching = jsonfile
 fact_caching_connection = /tmp
 stdout_callback = skippy
 library = ./library
+callback_whitelist = profile_tasks

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -6,3 +6,5 @@ host_key_checking=False
 gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = /tmp
+stdout_callback = skippy
+callback_whitelist = profile_tasks


### PR DESCRIPTION
- Starting from version 2.0 ansible has 'callback_whitelist =
  profile_tasks'. It allows to analyze CI to find some time regressions.
- Add skippy to CI's ansible.cfg

Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>