### PR TITLE
fix load balancer DNS name index evaluation in openssl.conf

### DIFF
--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -16,7 +16,7 @@ DNS.5 = localhost
 DNS.{{ 5 + loop.index }} = {{ host }}
 {% endfor %}
 {% if loadbalancer_apiserver is defined  and apiserver_loadbalancer_domain_name is defined %}
-{% set idx =  groups['kube-master'] | length | int + 5 %}
+{% set idx =  groups['kube-master'] | length | int + 5 + 1 %}
 DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% for host in groups['kube-master'] %}


### PR DESCRIPTION
Looks like OpenSSL still properly handles it, even with duplicated "DNS.X" items.