### PR TITLE
fix typo in "kibana_base_url" variable name

### DIFF
--- a/roles/kubernetes-apps/efk/kibana/defaults/main.yml
+++ b/roles/kubernetes-apps/efk/kibana/defaults/main.yml
@@ -4,4 +4,4 @@ kibana_mem_limit: 0M
 kibana_cpu_requests: 100m
 kibana_mem_requests: 0M
 kibana_service_port: 5601
-kibaba_base_url: "/api/v1/proxy/namespaces/kube-system/services/kibana-logging"
+kibana_base_url: "/api/v1/proxy/namespaces/kube-system/services/kibana-logging"


### PR DESCRIPTION
This typo lead to kibana_base_url being undefined and Kibana used
default base URL ("/") which is incorrect with default proxy-based
access.

/cc @bradbeam 