### PR TITLE
Mount host's /var/log into kubelet container

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -19,6 +19,7 @@
   {% endif -%}
   -v /sys:/sys:ro \
   -v {{ docker_daemon_graph }}:/var/lib/docker:rw \
+  -v /var/log:/var/log:rw \
   -v /var/lib/kubelet:/var/lib/kubelet:shared \
   -v /var/run:/var/run:rw \
   -v {{kube_config_dir}}:{{kube_config_dir}}:ro \


### PR DESCRIPTION
Kubelet is responsible for creating symlinks from /var/lib/docker to /var/log
to make fluentd logging collector work.
However without using host's /var/log those links are invisible to fluentd.

This is done on rkt configuration too.

/cc @bradbeam 