### PR TITLE
Ensure eth1 comes up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,6 +106,7 @@ Vagrant.configure("2") do |config|
       # Only execute once the Ansible provisioner,
       # when all the machines are up and ready.
       if i == $num_instances
+        config.vm.provision :shell, inline: "ifup eth1", privileged: true
         config.vm.provision "ansible" do |ansible|
           ansible.playbook = "cluster.yml"
           if File.exist?(File.join(File.dirname($inventory), "hosts"))

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,7 +106,7 @@ Vagrant.configure("2") do |config|
       # Only execute once the Ansible provisioner,
       # when all the machines are up and ready.
       if i == $num_instances
-        config.vm.provision :shell, inline: "ifup eth1", privileged: true
+        config.vm.provision :shell, inline: '[[ -x "$(command -v yum)" ]] && ifup eth1', privileged: true
         config.vm.provision "ansible" do |ansible|
           ansible.playbook = "cluster.yml"
           if File.exist?(File.join(File.dirname($inventory), "hosts"))


### PR DESCRIPTION
These roles assume a working eth1.  Vagrant is notorious brining
up interfaces on RHEL/CentOS instances.  The shell provisioner
will execute before the dependant ansible provisioner.