### PR TITLE
Fix fact tags

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -68,7 +68,6 @@
   with_items: "{{ manifests.results }}"
   when: inventory_hostname == groups['kube-master'][0] and item.item.type == "ds" and (manifests.changed or dnsmasq_config.changed)
 
-
 - name: Start Resources
   kube:
     name: dnsmasq
@@ -86,4 +85,3 @@
     port: 53
     delay: 5
   when: inventory_hostname == groups['kube-node'][0]
-  tags: facts

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -128,7 +128,6 @@
     state=directory
     owner=kube
     recurse=yes
-  tags: facts
 
 - name: Gen_certs | set permissions on keys
   shell: chmod 0600 {{ etcd_cert_dir}}/*key.pem

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -78,7 +78,6 @@
   register: calico_conf
   delegate_to: "{{groups['etcd'][0]}}"
   run_once: true
-  tags: facts
 
 - name: Calico | Configure calico network pool
   shell: >
@@ -141,7 +140,6 @@
 - set_fact:
     calico_pools: "{{ calico_pools_raw.stdout | from_json }}"
   run_once: true
-  tags: facts
 
 - name: Calico | Check if calico pool is properly configured
   fail:
@@ -150,7 +148,6 @@
   when: ( calico_pools['node']['nodes'] | length > 1 ) or
         ( not calico_pools['node']['nodes'][0]['key'] | search(".*{{ kube_pods_subnet | ipaddr('network') }}.*") )
   run_once: true
-  tags: facts
 
 - name: Calico | Set global as_num
   command: "{{ bin_dir}}/calicoctl config set asNumber {{ global_as_num }}"

--- a/roles/network_plugin/flannel/tasks/main.yml
+++ b/roles/network_plugin/flannel/tasks/main.yml
@@ -46,7 +46,6 @@
 
 - set_fact:
     flannel_subnet: "{{ flannel_subnet_output.stdout }}"
-  tags: facts
 
 - name: Flannel | Get flannel_mtu from subnet.env
   shell: cat /run/flannel/subnet.env | awk -F'=' '$1 == "FLANNEL_MTU" {print $2}'
@@ -56,7 +55,6 @@
 
 - set_fact:
     flannel_mtu: "{{ flannel_mtu_output.stdout }}"
-  tags: facts
 
 - set_fact:
     docker_options_file: >-
@@ -70,7 +68,6 @@
 
 - set_fact:
     docker_network_options: '"--bip={{ flannel_subnet }} --mtu={{ flannel_mtu }}"'
-  tags: facts
 
 - name: Flannel | Ensure path for docker network systemd drop-in
   file:


### PR DESCRIPTION
Ansible playbook fails when tags are limited to "facts,etcd" or to
"facts". This patch allows to run ansible-playbook to gather facts only
that don't require calico/flannel/weave components to be verified. This
allows to run ansible with 'facts,bootstrap-os' or just 'facts' to
gether facts that don't require specific components.

Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>