### PR TITLE
Use a virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ temp
 /ssh-bastion.conf
 **/*.sw[pon]
 vagrant/
+venv/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+venv: venv/bin/activate
+
+venv/bin/activate: requirements.txt
+	test -d venv || virtualenv --no-setuptools -p `which python` venv
+	. venv/bin/activate; pip install -r requirements.txt
+
+clean:
+	$(RM) -rf venv
+	find . -name "*.pyc" -exec $(RM) -rf {} \;
+
+.PHONY:clean venv

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ in order to avoid any issue during deployment you should disable your firewall.
 * The target servers are configured to allow **IPv4 forwarding**.
 * **Copy your ssh keys** to all the servers part of your inventory.
 * **Ansible v2.2 (or newer) and python-netaddr**
+  * Build and source a venv `make && venv/bin/activate`
 
 
 ## Network plugins


### PR DESCRIPTION
The instructions require a minimum version of Ansible and netaddr. Enforce
these dependencies through a venv. Particularly useful when switching between
other projects. Also, useful for the future as Kargo expands, and may require
additional dependencies.