### PR TITLE
Safe disable SELinux

### DIFF
--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -125,9 +125,15 @@
   tags: bootstrap-os
 
 # Todo : selinux configuration
+- name: Confirm selinux deployed
+  stat:
+    path: /etc/selinux/config
+  when: ansible_os_family == "RedHat"
+  register: slc
+
 - name: Set selinux policy to permissive
   selinux: policy=targeted state=permissive
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and slc.stat.exists == True
   changed_when: False
   tags: bootstrap-os
 


### PR DESCRIPTION
Sometimes, a sysadmin might outright delete the SELinux rpms and
delete the configuration. This causes the selinux module to fail
with
```
IOError: [Errno 2] No such file or directory: '/etc/selinux/config'\n",
"module_stdout": "", "msg": "MODULE FAILURE"}
```

This simply checks that /etc/selinux/config exists before we try
to set it Permissive.