### PR TITLE
iptables switch for docker

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -195,7 +195,7 @@ docker_daemon_graph: "/var/lib/docker"
 ## This string should be exactly as you wish it to appear.
 ## An obvious use case is allowing insecure-registry access
 ## to self hosted registries like so:
-docker_options: "--insecure-registry={{ kube_service_addresses }} --graph={{ docker_daemon_graph }}"
+docker_options: "--insecure-registry={{ kube_service_addresses }} --graph={{ docker_daemon_graph }} --iptables=false"
 docker_bin_dir: "/usr/bin"
 
 ## Uncomment this if you want to force overlay/overlay2 as docker storage driver

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,4 +1,4 @@
-docker_version: '1.12'
+docker_version: '1.13'
 
 docker_package_info:
   pkgs:

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -1,5 +1,4 @@
 ---
-docker_version: '1.12'
 docker_kernel_min_version: '3.10'
 
 # https://apt.dockerproject.org/repo/dists/ubuntu-xenial/main/filelist
@@ -7,7 +6,7 @@ docker_versioned_pkg:
   'latest': docker-engine
   '1.11': docker-engine=1.11.1-0~{{ ansible_distribution_release|lower }}
   '1.12': docker-engine=1.12.6-0~ubuntu-{{ ansible_distribution_release|lower }}
-  '1.13': docker-engine=1.13.0-0~ubuntu-{{ ansible_distribution_release|lower }}
+  '1.13': docker-engine=1.13.1-0~ubuntu-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt


### PR DESCRIPTION
    Statically disable iptables management for docker

    Docker 1.13 changes the behaviour of iptables defaults from allow
    to drop. This patch disables docker's iptables management as it was
    in Docker 1.12 [1]

    [1] https://github.com/docker/docker/pull/28257