### PR TITLE
Allow to specify etcd backend for kube-api

### DIFF
--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -29,3 +29,4 @@ kube_apiserver_memory_limit: 2000M
 kube_apiserver_cpu_limit: 800m
 kube_apiserver_memory_requests: 256M
 kube_apiserver_cpu_requests: 300m
+kube_apiserver_storage_backend: etcd2

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -41,6 +41,7 @@ spec:
     - --service-account-key-file={{ kube_cert_dir }}/apiserver-key.pem
     - --secure-port={{ kube_apiserver_port }}
     - --insecure-port={{ kube_apiserver_insecure_port }}
+    - --storage-backend={{ kube_apiserver_storage_backend }}
 {% if kube_api_runtime_config is defined %}
 {%   for conf in kube_api_runtime_config %}
     - --runtime-config={{ conf }}


### PR DESCRIPTION
Kubernetes project is about to set etcdv3 as default storage engine in
1.6. This patch allows to specify particular backend for
kube-apiserver. User may force the option to etcdv3 for new environment.
At the same time if the environment uses v2 it will continue uses it
until user decides to upgrade to v3.

Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>