### PR TITLE
optionally add an extra ip for the apiservers certificate

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -6,6 +6,11 @@
 ## but don't know about that address themselves.
 #access_ip: 1.1.1.1
 
+# The kube_apiserver_ext_ip is only used when generating the certificate protecting the apiservers
+# This is handy in case you want/have to access the apiserver through an external IP
+# that is not routable inside the cluster.
+# kube_apiserver_ext_ip: 10.10.10.10
+
 ### LOADBALANCING AND ACCESS MODES
 ## Enable multiaccess to configure etcd clients to access all of the etcd members directly
 ## as the "http://hostX:port, http://hostY:port, ..." and ignore the proxy loadbalancers.

--- a/roles/kubernetes/secrets/templates/openssl.conf.j2
+++ b/roles/kubernetes/secrets/templates/openssl.conf.j2
@@ -26,3 +26,6 @@ IP.{{ 2 * loop.index }} = {{ hostvars[host]['ip'] | default(hostvars[host]['ansi
 {% set idx =  groups['kube-master'] | length | int * 2 + 1 %}
 IP.{{ idx }} = {{ kube_apiserver_ip }}
 IP.{{ idx + 1 }} = 127.0.0.1
+{% if kube_apiserver_ext_ip is defined %}
+IP.{{ idx + 1 | string }} = {{ kube_apiserver_ext_ip }}
+{% endif %}


### PR DESCRIPTION
I needed a way to add an extra ip to the apiserver certificate. The ip is not routable inside the cluster so acces_ip cannot be used.