### PR TITLE
Uncomment one key/value in all.yml

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,4 +1,3 @@
-
 ## The access_ip variable is used to define how other nodes should access
 ## the node.  This is used in flannel to allow other flannel nodes to see
 ## this node for example.  The access_ip is really useful AWS and Google
@@ -32,7 +31,7 @@
 ## modules.
 # kubelet_load_modules: false
 
-## Internal network total size. This is the prefix of the                                                                         
+## Internal network total size. This is the prefix of the
 ## entire network. Must be unused in your environment.
 #kube_network_prefix: 18
 
@@ -79,7 +78,6 @@
 #kpm_packages:
 #  - name: kube-system/grafana
 
-
 ## Certificate Management
 ## This setting determines whether certs are generated via scripts or whether a
 ## cluster of Hashicorp's Vault is started to issue certificates (using etcd
@@ -87,4 +85,4 @@
 #cert_management: script
 
 ## Please specify true if you want to perform a kernel upgrade
-#kernel_upgrade: false
+kernel_upgrade: false


### PR DESCRIPTION
all.yaml shouldn't be empty otherwise ansible won't be able to merge 2
dicts.

Related bug: ansible/issues/21889