### PR TITLE
Fix cluster.yml file extension in docs

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -162,7 +162,7 @@ ansible-playbook -i inventory/inventory.ini -e dns_server='' cluster.yml --tags 
 And this prepares all container images localy (at the ansible runner node) without installing
 or upgrading related stuff or trying to upload container to K8s cluster nodes:
 ```
-ansible-playbook -i inventory/inventory.ini cluster.yaml \
+ansible-playbook -i inventory/inventory.ini cluster.yml \
     -e download_run_once=true -e download_localhost=true \
     --tags download --skip-tags upload,upgrade
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,7 +50,7 @@ and start the deployment:
 **IMPORTANT: Edit my_inventory/groups_vars/*.yaml to override data vars**
 
 ```
-ansible-playbook -i my_inventory/inventory.cfg cluster.yaml -b -v \
+ansible-playbook -i my_inventory/inventory.cfg cluster.yml -b -v \
   --private-key=~/.ssh/private_key
 ```
 


### PR DESCRIPTION
When you run ```ansible-playbook -i my_inventory/inventory.cfg cluster.yaml -b -v``` as described in docs you get the error  ```ERROR! the playbook: cluster.yaml could not be found```,because the right file is ```cluster.yml```