### PR TITLE
Fixed counter in ETCD Openssl.conf

### DIFF
--- a/roles/etcd/templates/openssl.conf.j2
+++ b/roles/etcd/templates/openssl.conf.j2
@@ -28,7 +28,7 @@ DNS.1 = localhost
 DNS.{{ 1 + loop.index }} = {{ host }}
 {% endfor %}
 {% if loadbalancer_apiserver is defined  and apiserver_loadbalancer_domain_name is defined %}
-{% set idx =  groups['etcd'] | length | int + 1 %}
+{% set idx =  groups['etcd'] | length | int + 2 %}
 DNS.{{ idx | string }} = {{ apiserver_loadbalancer_domain_name }}
 {% endif %}
 {% for host in groups['etcd'] %}


### PR DESCRIPTION
When a apiserver_loadbalancer_domain_name is added to the Openssl.conf
the counter gets not increased correctly. This didnt seem to have an
effect at the current kargo version.