### PR TITLE
Added Support for OpenID Connect Authentication

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -57,6 +57,19 @@ kube_users:
     pass: "{{kube_api_pwd}}"
     role: admin
 
+
+## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
+## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)
+# kube_oidc_auth: false
+# kube_oidc_url: https:// ...
+# kube_oidc_client_id: kubernetes
+## Optional settings for OIDC
+# kube_oidc_ca_file: {{ kube_cert_dir }}/ca.pem
+# kube_oidc_username_claim: sub
+# kube_oidc_groups_claim: groups
+
+
+
 # Choose network plugin (calico, weave or flannel)
 # Can also be set to 'cloud', which lets the cloud provider setup appropriate routing
 kube_network_plugin: calico

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -30,3 +30,13 @@ kube_apiserver_cpu_limit: 800m
 kube_apiserver_memory_requests: 256M
 kube_apiserver_cpu_requests: 300m
 kube_apiserver_storage_backend: etcd2
+
+## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
+## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)
+kube_oidc_auth: false
+#kube_oidc_url: https:// ...
+# kube_oidc_client_id: kubernetes
+## Optional settings for OIDC
+# kube_oidc_ca_file: {{ kube_cert_dir }}/ca.pem
+# kube_oidc_username_claim: sub
+# kube_oidc_groups_claim: groups

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -39,6 +39,19 @@ spec:
     - --tls-private-key-file={{ kube_cert_dir }}/apiserver-key.pem
     - --token-auth-file={{ kube_token_dir }}/known_tokens.csv
     - --service-account-key-file={{ kube_cert_dir }}/apiserver-key.pem
+{% if kube_oidc_auth|default(false) and kube_oidc_url is defined and kube_oidc_client_id is defined %}
+    - --oidc-issuer-url={{ kube_oidc_url }}
+    - --oidc-client-id={{ kube_oidc_client_id }}
+{%   if kube_oidc_ca_file is defined %}
+    - --oidc-ca-file={{ kube_oidc_ca_file }}
+{%   endif %}
+{%   if kube_oidc_username_claim is defined %}
+    - --oidc-username-claim={{ kube_oidc_username_claim }}
+{%   endif %}
+{%   if kube_oidc_groups_claim is defined %}
+    - --oidc-groups-claim={{ kube_oidc_groups_claim }}
+{%   endif %}
+{% endif %}
     - --secure-port={{ kube_apiserver_port }}
     - --insecure-port={{ kube_apiserver_insecure_port }}
     - --storage-backend={{ kube_apiserver_storage_backend }}


### PR DESCRIPTION
To use OpenID Connect Authentication beside deploying an OpenID Connect
Identity Provider it is necesarry to pass additional arguments to the Kube API Server.
These required arguments were added to the kube apiserver manifest.