### PR TITLE
Granular authentication Control

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -58,16 +58,22 @@ kube_users:
     role: admin
 
 
+
+## It is possible to activate / deactivate selected authentication methods (basic auth, static token auth)
+#kube_oidc_auth: false
+#kube_basic_auth: false
+#kube_token_auth: false
+
+
 ## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
 ## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)
-# kube_oidc_auth: false
+
 # kube_oidc_url: https:// ...
 # kube_oidc_client_id: kubernetes
 ## Optional settings for OIDC
 # kube_oidc_ca_file: {{ kube_cert_dir }}/ca.pem
 # kube_oidc_username_claim: sub
 # kube_oidc_groups_claim: groups
-
 
 
 # Choose network plugin (calico, weave or flannel)

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -31,9 +31,15 @@ kube_apiserver_memory_requests: 256M
 kube_apiserver_cpu_requests: 300m
 kube_apiserver_storage_backend: etcd2
 
+
+## Enable/Disable Kube API Server Authentication Methods
+kube_basic_auth: true
+kube_token_auth: true
+kube_oidc_auth: false
+
 ## Variables for OpenID Connect Configuration https://kubernetes.io/docs/admin/authentication/
 ## To use OpenID you have to deploy additional an OpenID Provider (e.g Dex, Keycloak, ...)
-kube_oidc_auth: false
+
 #kube_oidc_url: https:// ...
 # kube_oidc_client_id: kubernetes
 ## Optional settings for OIDC

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -34,10 +34,14 @@ spec:
     - --service-cluster-ip-range={{ kube_service_addresses }}
     - --service-node-port-range={{ kube_apiserver_node_port_range }}
     - --client-ca-file={{ kube_cert_dir }}/ca.pem
+{% if kube_basic_auth|default(true) %}
     - --basic-auth-file={{ kube_users_dir }}/known_users.csv
+{% endif %}
     - --tls-cert-file={{ kube_cert_dir }}/apiserver.pem
     - --tls-private-key-file={{ kube_cert_dir }}/apiserver-key.pem
+{% if kube_token_auth|default(true) %}
     - --token-auth-file={{ kube_token_dir }}/known_tokens.csv
+{% endif %}
     - --service-account-key-file={{ kube_cert_dir }}/apiserver-key.pem
 {% if kube_oidc_auth|default(false) and kube_oidc_url is defined and kube_oidc_client_id is defined %}
     - --oidc-issuer-url={{ kube_oidc_url }}

--- a/roles/kubernetes/secrets/tasks/check-tokens.yml
+++ b/roles/kubernetes/secrets/tasks/check-tokens.yml
@@ -14,7 +14,7 @@
 - name: "Check_tokens | Set 'sync_tokens' and 'gen_tokens' to true"
   set_fact:
     gen_tokens: true
-  when: not known_tokens_master.stat.exists
+  when: not known_tokens_master.stat.exists and kube_token_auth|default(true)
   run_once: true
 
 - name: "Check tokens | check if a cert already exists"

--- a/roles/kubernetes/secrets/tasks/main.yml
+++ b/roles/kubernetes/secrets/tasks/main.yml
@@ -33,7 +33,7 @@
     line: '{{ item.value.pass }},{{ item.key }},{{ item.value.role }}'
     backup: yes
   with_dict: "{{ kube_users }}"
-  when: inventory_hostname in "{{ groups['kube-master'] }}"
+  when: inventory_hostname in "{{ groups['kube-master'] }}" and kube_basic_auth|default(true)
   notify: set secret_changed
 
 #


### PR DESCRIPTION
It is now possible to deactivate selected authentication methods
(x509, basic auth, token auth) inside the cluster by adding
removing the required arguments to the Kube API Server.

This enables developers select / enable only the required authentication methods.