### PR TITLE
Lower default memory requests

### DIFF
--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -22,7 +22,7 @@ exechealthz_image_tag: "{{ exechealthz_version }}"
 calico_policy_controller_cpu_limit: 100m
 calico_policy_controller_memory_limit: 256M
 calico_policy_controller_cpu_requests: 30m
-calico_policy_controller_memory_requests: 128M
+calico_policy_controller_memory_requests: 64M
 
 # Netchecker
 deploy_netchecker: false
@@ -40,7 +40,7 @@ netchecker_agent_memory_requests: 64M
 netchecker_server_cpu_limit: 100m
 netchecker_server_memory_limit: 256M
 netchecker_server_cpu_requests: 50m
-netchecker_server_memory_requests: 128M
+netchecker_server_memory_requests: 64M
 
 # SSL
 etcd_cert_dir: "/etc/ssl/etcd/ssl"

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -16,11 +16,11 @@ kubelet_cpu_limit: 100m
 kubelet_status_update_frequency: 10s
 kube_proxy_memory_limit: 2000M
 kube_proxy_cpu_limit: 500m
-kube_proxy_memory_requests: 256M
+kube_proxy_memory_requests: 64M
 kube_proxy_cpu_requests: 150m
 nginx_memory_limit: 512M
 nginx_cpu_limit: 300m
-nginx_memory_requests: 64M
+nginx_memory_requests: 32M
 nginx_cpu_requests: 50m
 
 # kube_api_runtime_config:

--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -23,9 +23,9 @@ global_as_num: "64512"
 # Limits for apps
 calico_node_memory_limit: 500M
 calico_node_cpu_limit: 300m
-calico_node_memory_requests: 256M
+calico_node_memory_requests: 64M
 calico_node_cpu_requests: 150m
 calicoctl_memory_limit: 170M
 calicoctl_cpu_limit: 100m
-calicoctl_memory_requests: 70M
+calicoctl_memory_requests: 32M
 calicoctl_cpu_requests: 50m

--- a/roles/network_plugin/calico/rr/defaults/main.yml
+++ b/roles/network_plugin/calico/rr/defaults/main.yml
@@ -9,5 +9,5 @@ etcd_cert_dir: /etc/ssl/etcd/ssl
 # Limits for apps
 calico_rr_memory_limit: 1000M
 calico_rr_cpu_limit: 300m
-calico_rr_memory_requests: 500M
+calico_rr_memory_requests: 128M
 calico_rr_cpu_requests: 150m

--- a/roles/network_plugin/canal/defaults/main.yml
+++ b/roles/network_plugin/canal/defaults/main.yml
@@ -20,14 +20,14 @@ canal_policy_dir: /etc/kubernetes/policy
 # Limits for apps
 calico_node_memory_limit: 500M
 calico_node_cpu_limit: 200m
-calico_node_memory_requests: 256M
+calico_node_memory_requests: 64M
 calico_node_cpu_requests: 100m
 flannel_memory_limit: 500M
 flannel_cpu_limit: 200m
-flannel_memory_requests: 256M
+flannel_memory_requests: 64M
 flannel_cpu_requests: 100m
 calicoctl_memory_limit: 170M
 calicoctl_cpu_limit: 100m
-calicoctl_memory_requests: 70M
+calicoctl_memory_requests: 32M
 calicoctl_cpu_requests: 50m
 

--- a/roles/network_plugin/flannel/defaults/main.yml
+++ b/roles/network_plugin/flannel/defaults/main.yml
@@ -14,7 +14,7 @@ flannel_backend_type: "vxlan"
 # Limits for apps
 flannel_memory_limit: 500M
 flannel_cpu_limit: 300m
-flannel_memory_requests: 256M
+flannel_memory_requests: 64M
 flannel_cpu_requests: 150m
 
 flannel_cert_dir: /etc/flannel/certs

--- a/roles/network_plugin/weave/defaults/main.yml
+++ b/roles/network_plugin/weave/defaults/main.yml
@@ -2,5 +2,5 @@
 # Limits
 weave_memory_limit: 400M
 weave_cpu_limit: 30m
-weave_memory_requests: 200M
+weave_memory_requests: 64M
 weave_cpu_requests: 10m


### PR DESCRIPTION
This is to address out of memory issues on CI as well as help
fit deployments for people starting out with kargo on smaller
machines