### PR TITLE
Allow connections from pods to local endpoints

### DIFF
--- a/docs/calico.md
+++ b/docs/calico.md
@@ -147,6 +147,16 @@ The inventory above will deploy the following topology assuming that calico's
 
 ![Image](figures/kargo-calico-rr.png?raw=true)
 
+##### Optional : Define default endpoint to host action
+
+By default Calico blocks traffic from endpoints to the host itself by using an iptables DROP action. When using it in kubernetes the action has to be changed to RETURN (default in kargo) or ACCEPT (see https://github.com/projectcalico/felix/issues/660 and https://github.com/projectcalico/calicoctl/issues/1389). Otherwise all network packets from pods (with hostNetwork=False) to services endpoints (with hostNetwork=True) withing the same node are dropped.
+
+
+To re-define default action please set the following variable in your inventory:
+```
+calico_endpoint_to_host_action: "ACCEPT"
+```
+
 Cloud providers configuration
 =============================
 

--- a/roles/network_plugin/calico/templates/calico-node.service.j2
+++ b/roles/network_plugin/calico/templates/calico-node.service.j2
@@ -12,6 +12,7 @@ ExecStart={{ docker_bin_dir }}/docker run --net=host --privileged \
  -e IP=${CALICO_IP} \
  -e IP6=${CALICO_IP6} \
  -e CALICO_NETWORKING_BACKEND=${CALICO_NETWORKING_BACKEND} \
+ -e FELIX_DEFAULTENDPOINTTOHOSTACTION={{ calico_endpoint_to_host_action|default('RETURN') }} \
  -e AS=${CALICO_AS} \
  -e NO_DEFAULT_POOLS=${CALICO_NO_DEFAULT_POOLS} \
  -e CALICO_LIBNETWORK_ENABLED=${CALICO_LIBNETWORK_ENABLED} \


### PR DESCRIPTION
By default Calico blocks traffic from endpoints
to the host itself by using an iptables DROP
action. It could lead to a situation when service
has one alive endpoint, but pods which run on
the same node can not access it. Changed the action
to RETURN.