### PR TITLE
Adding flag for docker container in kubelet w/ rkt

### DIFF
--- a/roles/kubernetes/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.rkt.service.j2
@@ -49,7 +49,12 @@ ExecStart=/usr/bin/rkt run \
         --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
         --mount volume=var-log,target=/var/log \
         --stage1-from-dir=stage1-fly.aci \
+{% if kube_hyperkube_image_repo == "docker" %}
+        --insecure-options=image \
+        docker://{{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} \
+{% else %}
         {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} \
+{% endif %}
         --uuid-file-save=/var/run/kubelet.uuid \
         --debug --exec=/kubelet -- \
                 $KUBE_LOGTOSTDERR \


### PR DESCRIPTION
Open to suggestions on a better way to implement this, and it'll need to get replicated to the other rkt service templates ( etcd, vault ), and I'm noticing I'm missing a default value for this.

If someone wants to use a container from docker hub, we'll need to add the following flags. I think we get around it in current state by pulling from quay.io. 