### PR TITLE
Added host_vars to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.retry
 inventory/vagrant_ansible_inventory
 inventory/group_vars/fake_hosts.yml
-inventory/host_vars/k8s-0*/
+inventory/host_vars/
 temp
 .idea
 .tox

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.retry
 inventory/vagrant_ansible_inventory
 inventory/group_vars/fake_hosts.yml
+inventory/host_vars/k8s-0*/
 temp
 .idea
 .tox


### PR DESCRIPTION
Since inventory ships with kargo, the ability to change functionality
without having a dirty git index is nice.  An example, we wish to change
is the version of docker deployed to our CentOS systems.  Due to an issue
with tiller and docker 1.13, we wish to deploy docker 1.12.  Since this
change does not belong in Kargo, we wish to locally override the docker
version, until the issue is sorted.