### PR TITLE
Use docker-engine 1.13.1

### DIFF
--- a/roles/docker/vars/debian.yml
+++ b/roles/docker/vars/debian.yml
@@ -5,7 +5,7 @@ docker_versioned_pkg:
   'latest': docker-engine
   '1.11': docker-engine=1.11.2-0~{{ ansible_distribution_release|lower }}
   '1.12': docker-engine=1.12.6-0~debian-{{ ansible_distribution_release|lower }}
-  '1.13': docker-engine=1.13.0-0~debian-{{ ansible_distribution_release|lower }}
+  '1.13': docker-engine=1.13.1-0~debian-{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt

--- a/roles/docker/vars/redhat.yml
+++ b/roles/docker/vars/redhat.yml
@@ -6,7 +6,7 @@ docker_versioned_pkg:
   'latest': docker-engine
   '1.11': docker-engine-1.11.2-1.el7.centos
   '1.12': docker-engine-1.12.6-1.el7.centos
-  '1.13': docker-engine-1.13.0-1.el7.centos
+  '1.13': docker-engine-1.13.1-1.el7.centos
 
 docker_package_info:
   pkg_mgr: yum


### PR DESCRIPTION
The default version of Docker was switched to 1.13 in #1059.  This
change also bumped ubuntu from installing docker-engine 1.13.0 to
1.13.1.  This PR updates os families which had 1.13 defined, but
were using 1.13.0.

The impetus for this change is an issue running tiller 1.2.3 on
docker 1.13.0.  See discussion [1][2].

[1] https://github.com/kubernetes/helm/issues/1838
[2] https://github.com/kubernetes-incubator/kargo/pull/1100