### PR TITLE
[wip] Use async for slow long loop cert tasks

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -4,6 +4,8 @@
     path: "{{ etcd_cert_dir }}/{{ item }}"
     get_md5: no
   delegate_to: "{{groups['etcd'][0]}}"
+  async: 1000
+  poll: 0
   register: etcdcert_master
   run_once: true
   with_items: >-
@@ -13,6 +15,12 @@
        'node-{{ host }}-key.pem'
        {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]
+
+- name: "Check_certs | check on checking certs"
+  async_status: jid={{ etcdcert_master.ansible_job_id }}
+  register: job_result
+  until: job_result.finished
+  retries: 30
 
 - name: "Check_certs | Set default value for 'sync_certs', 'gen_certs' and 'etcd_secret_changed' to false"
   set_fact:

--- a/roles/kubernetes/secrets/tasks/check-certs.yml
+++ b/roles/kubernetes/secrets/tasks/check-certs.yml
@@ -3,6 +3,8 @@
   stat:
     path: "{{ kube_cert_dir }}/{{ item }}"
   delegate_to: "{{groups['kube-master'][0]}}"
+  async: 1000
+  poll: 0
   register: kubecert_master
   run_once: true
   with_items: >-
@@ -11,6 +13,12 @@
        'node-{{ host }}-key.pem'
        {% if not loop.last %}{{','}}{% endif %}
        {% endfor %}]
+
+- name: "Check_certs | check on checking certs"
+  async_status: jid={{ kubecert_master.ansible_job_id }}
+  register: job_result
+  until: job_result.finished
+  retries: 30
 
 - name: "Check_certs | Set default value for 'sync_certs', 'gen_certs', and 'secret_changed'  to false"
   set_fact:

--- a/roles/kubernetes/secrets/tasks/gen_tokens.yml
+++ b/roles/kubernetes/secrets/tasks/gen_tokens.yml
@@ -30,11 +30,19 @@
     - [ 'system:kubelet' ]
     - "{{ groups['kube-node'] }}"
   register: gentoken_node
+  async: 1000
+  poll: 0
   changed_when: "'Added' in gentoken_node.stdout"
   notify: set secret_changed
   run_once: yes
   delegate_to: "{{groups['kube-master'][0]}}"
   when: gen_tokens|default(false)
+
+- name: "Gen_tokens | check on generating tokens"
+  async_status: jid={{ gentoken_node.ansible_job_id }}
+  register: job_result
+  until: job_result.finished
+  retries: 30
 
 - name: Gen_tokens | Get list of tokens from first master
   shell: "(find {{ kube_token_dir }} -maxdepth 1 -type f)"


### PR DESCRIPTION
Checking for certs and generating tokens takes
up to 1.5s per node for each of three tasks. Async
should parallelize this and reduce the time significantly.