### PR TITLE
Remove standalone etcd specific play, cleanup host mode

### DIFF
--- a/cluster.yml
+++ b/cluster.yml
@@ -39,17 +39,17 @@
     - { role: kargo-defaults, when: "cert_management == 'vault'" }
     - { role: vault, tags: vault, vault_bootstrap: true, when: "cert_management == 'vault'" }
 
-- hosts: etcd:!k8s-cluster
+- hosts: etcd
   any_errors_fatal: true
   roles:
     - { role: kargo-defaults}
-    - { role: etcd, tags: etcd }
+    - { role: etcd, tags: etcd, etcd_cluster_setup: true }
 
 - hosts: k8s-cluster
   any_errors_fatal: true
   roles:
     - { role: kargo-defaults}
-    - { role: etcd, tags: etcd }
+    - { role: etcd, tags: etcd, etcd_cluster_setup: false }
 
 - hosts: etcd:k8s-cluster:vault
   any_errors_fatal: true

--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Set to false to only do certificate management
+etcd_cluster_setup: true
+
 etcd_bin_dir: "{{ local_release_dir }}/etcd/etcd-{{ etcd_version }}-linux-amd64/"
 etcd_data_dir: "/var/lib/etcd"
 

--- a/roles/etcd/tasks/install_host.yml
+++ b/roles/etcd/tasks/install_host.yml
@@ -1,9 +1,0 @@
----
-- name: Install | Copy etcd binary from downloaddir
-  command: rsync -piu "{{ etcd_bin_dir }}/etcd" "{{ bin_dir }}/etcd"
-  register: etcd_copy
-  changed_when: false
-
-- name: Install | Copy etcdctl binary from downloaddir
-  command: rsync -piu "{{ etcd_bin_dir }}/etcdctl" "{{ bin_dir }}/etcdctl"
-  changed_when: false

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: pre_upgrade.yml
+  when: etcd_cluster_setup
   tags: etcd-pre-upgrade
 
 - include: check_certs.yml
@@ -27,19 +28,18 @@
   tags: upgrade
 
 - include: set_cluster_health.yml
-  when: is_etcd_master
+  when: is_etcd_master and etcd_cluster_setup
 
 - include: configure.yml
-  when: is_etcd_master
+  when: is_etcd_master and etcd_cluster_setup
 
 - include: refresh_config.yml
-  when: is_etcd_master
+  when: is_etcd_master and etcd_cluster_setup
 
-- name: Restart etcd if binary or certs changed
+- name: Restart etcd if certs changed
   command: /bin/true
   notify: restart etcd
-  when: etcd_deployment_type == "host" and etcd_copy.stdout_lines and is_etcd_master
-    or etcd_secret_changed|default(false)
+  when: is_etcd_master and etcd_secret_changed|default(false)
 
 # reload-systemd
 - meta: flush_handlers
@@ -49,13 +49,13 @@
     name: etcd
     state: started
     enabled: yes
-  when: is_etcd_master
+  when: is_etcd_master and etcd_cluster_setup
 
 # After etcd cluster is assembled, make sure that
 # initial state of the cluster is in `existing`
 # state insted of `new`.
 - include: set_cluster_health.yml
-  when: is_etcd_master
+  when: is_etcd_master and etcd_cluster_setup
 
 - include: refresh_config.yml
-  when: is_etcd_master
+  when: is_etcd_master and etcd_cluster_setup

--- a/upgrade-cluster.yml
+++ b/upgrade-cluster.yml
@@ -39,17 +39,17 @@
     - { role: kargo-defaults, when: "cert_management == 'vault'" }
     - { role: vault, tags: vault, vault_bootstrap: true, when: "cert_management == 'vault'" }
 
-- hosts: etcd:!k8s-cluster
+- hosts: etcd
   any_errors_fatal: true
   roles:
     - { role: kargo-defaults}
-    - { role: etcd, tags: etcd }
+    - { role: etcd, tags: etcd, etcd_cluster_setup: true }
 
 - hosts: k8s-cluster
   any_errors_fatal: true
   roles:
     - { role: kargo-defaults}
-    - { role: etcd, tags: etcd }
+    - { role: etcd, tags: etcd, etcd_cluster_setup: false }
 
 - hosts: etcd:k8s-cluster:vault
   any_errors_fatal: true


### PR DESCRIPTION
Now etcd role can optionally disable etcd cluster setup for faster
deployment when it is combined with etcd role.