### PR TITLE
Fix for CoreOS Docu

### DIFF
--- a/docs/coreos.md
+++ b/docs/coreos.md
@@ -13,12 +13,4 @@ Before running the cluster playbook you must satisfy the following requirements:
 
 * On each CoreOS nodes a writable directory **/opt/bin** (~400M disk space)
 
-* Uncomment the variable **ansible\_python\_interpreter** in the file `inventory/group_vars/all.yml`
-
-* run the Python bootstrap playbook
-
-```
-ansible-playbook -u smana -e ansible_ssh_user=smana  -b --become-user=root -i inventory/inventory.cfg coreos-bootstrap.yml
-```
-
 Then you can proceed to [cluster deployment](#run-deployment)


### PR DESCRIPTION
CoreOS docu was referencing outdated bootstrap playbook that
is now part of the kargo deployment itself.