### PR TITLE
Added Jinja 2.8 to Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Requirements
 
 * **Ansible v2.2 (or newer) and python-netaddr is installed on the machine
   that will run Ansible commands**
+* **Jinja 2.8 (or newer) is required to run the Ansible Playbooks**
 * The target servers must have **access to the Internet** in order to pull docker images.
 * The target servers are configured to allow **IPv4 forwarding**.
 * **Your ssh key must be copied** to all the servers part of your inventory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible>=2.2.1
 netaddr
+jinja>=2.8


### PR DESCRIPTION
Added Jinja 2.8 as requirement to the documentation and pip requirements file.
This Jinja version (or newer) is required to run the current Ansible Playbooks.