### PR TITLE
Update calico to 1.1.0-rc8

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -22,7 +22,7 @@ kube_version: v1.5.3
 etcd_version: v3.0.6
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
-calico_version: "v1.0.2"
+calico_version: "v1.1.0-rc8"
 calico_cni_version: "v1.5.6"
 calico_policy_version: "v0.5.2"
 weave_version: 1.8.2


### PR DESCRIPTION
Fixes bug in CentOS/RHEL in felix related to overlayfs driver.