### PR TITLE
fix jinja package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ansible>=2.2.1
 netaddr
-jinja>=2.8
+jinja2>=2.8


### PR DESCRIPTION
Jinja 2.* releases are published under `Jinja2` name.

/cc: @VincentS 