### PR TITLE
limit jinja2 version to <2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,14 @@
 ansible>=2.2.1
 netaddr
-jinja2>=2.8
+# Ansible 2.2.1 requires jinja2<2.9, see <https://github.com/ansible/ansible/blob/v2.2.1.0-1/setup.py#L25>,
+# but without explicit limiting upper jinja2 version here pip ignores
+# Ansible requirements and installs latest available jinja2
+# (pip is not very smart here), which is incompatible with with
+# Ansible 2.2.1.
+# With incompatible jinja2 version "ansible-vault create" (and probably other parts)
+# fails with:
+#   ERROR! Unexpected Exception: The 'jinja2<2.9' distribution was not found 
+#   and is required by ansible
+# This upper limit should be removed in 2.2.2 release, see:
+# <https://github.com/ansible/ansible/commit/978311bf3f91dae5806ab72b665b0937adce38ad>
+jinja2>=2.8,<2.9


### PR DESCRIPTION
Ansible 2.2.1 requires jinja2<2.9, see <https://github.com/ansible/ansible/blob/v2.2.1.0-1/setup.py#L25>,
but without explicit limiting upper jinja2 version here pip ignores
Ansible requirements and installs latest available jinja2
(pip is not very smart here), which is incompatible with with
Ansible 2.2.1.
With incompatible jinja2 version "ansible-vault create" (and probably other parts)
fails with:
  ERROR! Unexpected Exception: The 'jinja2<2.9' distribution was not found 
  and is required by ansible
This upper limit should be removed in 2.2.2 release, see:
<https://github.com/ansible/ansible/commit/978311bf3f91dae5806ab72b665b0937adce38ad>