### PR TITLE
Change wait for dnsmasq to skip if there are no kube-nodes in play

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -77,6 +77,6 @@
   wait_for:
     host: "{{dns_server}}"
     port: 53
-    delay: 5
-  when: inventory_hostname == groups['kube-node'][0]
+    timeout: 180
+  when: inventory_hostname == groups['kube-node'][0] and groups['kube-node'][0] in ansible_play_hosts
 

--- a/roles/kubernetes/secrets/tasks/check-tokens.yml
+++ b/roles/kubernetes/secrets/tasks/check-tokens.yml
@@ -27,7 +27,7 @@
     sync_tokens: true
   when: >-
       {%- set tokens = {'sync': False} -%}
-      {%- for server in groups['kube-master'] | intersect(play_hosts)
+      {%- for server in groups['kube-master'] | intersect(ansible_play_hosts)
          if (not hostvars[server].known_tokens.stat.exists) or
          (hostvars[server].known_tokens.stat.checksum != known_tokens_master.stat.checksum|default('')) -%}
          {%- set _ = tokens.update({'sync': True}) -%}


### PR DESCRIPTION
Also changed unnecessary delay to a max timeout (now defaulting to 1s sleep
between tries)