### PR TITLE
1169 - fix docker systemd unit

### DIFF
--- a/roles/docker/templates/docker_atomic.service.j2
+++ b/roles/docker/templates/docker_atomic.service.j2
@@ -9,7 +9,6 @@ Type=notify
 NotifyAccess=all
 EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage
-EnvironmentFile=-/etc/sysconfig/docker-network
 Environment=GOTRACEBACK=crash
 Environment=DOCKER_HTTP_HOST_COMPAT=1
 Environment=PATH=/usr/libexec/docker:/usr/bin:/usr/sbin


### PR DESCRIPTION
The docker-network environment file masks the new values
put into /etc/systemd/system/docker.service.d/flannel-options.conf
to renumber the docker0 to work correctly with flannel.