### PR TITLE
Fix docker restart in atomic

### DIFF
--- a/roles/network_plugin/flannel/handlers/main.yml
+++ b/roles/network_plugin/flannel/handlers/main.yml
@@ -15,7 +15,6 @@
     - Flannel | reload docker.socket
     - Flannel | configure docker live-restore true (atomic)
     - Flannel | reload docker
-    - Flannel | configure docker live-restore false (atomic)
     - Flannel | reload docker (atomic)
     - Flannel | pause while Docker restarts
     - Flannel | wait for docker

--- a/roles/network_plugin/flannel/handlers/main.yml
+++ b/roles/network_plugin/flannel/handlers/main.yml
@@ -15,7 +15,6 @@
     - Flannel | reload docker.socket
     - Flannel | configure docker live-restore true (atomic)
     - Flannel | reload docker
-    - Flannel | reload docker (atomic)
     - Flannel | pause while Docker restarts
     - Flannel | wait for docker
 

--- a/roles/network_plugin/flannel/handlers/main.yml
+++ b/roles/network_plugin/flannel/handlers/main.yml
@@ -4,14 +4,18 @@
   failed_when: false
   notify: Flannel | restart docker
 
+# special cases for atomic because it defaults to live-restore: true
+# So we disable live-restore to pickup the new flannel IP.  After
+# we enable it, we have to restart docker again to pickup the new
+# setting and restore the original behavior
 - name: Flannel | restart docker
   command: /bin/true
   notify:
     - Flannel | reload systemd
     - Flannel | reload docker.socket
-    - Flannel | reconfigure docker restart behavior (atomic)
+    - Flannel | configure docker live-restore true (atomic)
     - Flannel | reload docker
-    - Flannel | restore docker restart behavior (atomic)
+    - Flannel | configure docker live-restore false (atomic)
     - Flannel | reload docker (atomic)
     - Flannel | pause while Docker restarts
     - Flannel | wait for docker
@@ -25,7 +29,7 @@
     state: restarted
   when: ansible_os_family in ['CoreOS', 'Container Linux by CoreOS']
 
-- name: Flannel | reconfigure docker restart behavior (atomic)
+- name: Flannel | configure docker live-restore true (atomic)
   replace:
     name: /etc/docker/daemon.json
     regexp: '"live-restore":.*true'
@@ -37,7 +41,7 @@
     name: docker
     state: restarted
 
-- name: Flannel | restore docker restart behavior (atomic)
+- name: Flannel | configure docker live-restore false (atomic)
   replace:
     name: /etc/docker/daemon.json
     regexp: '"live-restore": false'

--- a/roles/network_plugin/flannel/handlers/main.yml
+++ b/roles/network_plugin/flannel/handlers/main.yml
@@ -9,7 +9,9 @@
   notify:
     - Flannel | reload systemd
     - Flannel | reload docker.socket
+    - Flannel | reconfigure docker restart behavior (atomic)
     - Flannel | reload docker
+    - Flannel | restore docker restart behavior (atomic)
     - Flannel | reload docker (atomic)
     - Flannel | pause while Docker restarts
     - Flannel | wait for docker
@@ -23,14 +25,29 @@
     state: restarted
   when: ansible_os_family in ['CoreOS', 'Container Linux by CoreOS']
 
+- name: Flannel | reconfigure docker restart behavior (atomic)
+  replace:
+    name: /etc/docker/daemon.json
+    regexp: '"live-restore":.*true'
+    replace: '"live-restore": false'
+  when: is_atomic
+
 - name: Flannel | reload docker
   service:
     name: docker
     state: restarted
-  when: not is_atomic
+
+- name: Flannel | restore docker restart behavior (atomic)
+  replace:
+    name: /etc/docker/daemon.json
+    regexp: '"live-restore": false'
+    replace: '"live-restore": true'
+  when: is_atomic
 
 - name: Flannel | reload docker (atomic)
-  shell: systemctl stop docker && runc list | awk '!/ID/ {print $1}' | xargs -n 1 -I ID runc kill ID KILL && systemctl start docker
+  service:
+    name: docker
+    state: restarted
   when: is_atomic
 
 - name: Flannel | pause while Docker restarts

--- a/roles/network_plugin/flannel/handlers/main.yml
+++ b/roles/network_plugin/flannel/handlers/main.yml
@@ -41,19 +41,6 @@
     name: docker
     state: restarted
 
-- name: Flannel | configure docker live-restore false (atomic)
-  replace:
-    name: /etc/docker/daemon.json
-    regexp: '"live-restore": false'
-    replace: '"live-restore": true'
-  when: is_atomic
-
-- name: Flannel | reload docker (atomic)
-  service:
-    name: docker
-    state: restarted
-  when: is_atomic
-
 - name: Flannel | pause while Docker restarts
   pause:
     seconds: 10

--- a/roles/network_plugin/flannel/handlers/main.yml
+++ b/roles/network_plugin/flannel/handlers/main.yml
@@ -10,6 +10,7 @@
     - Flannel | reload systemd
     - Flannel | reload docker.socket
     - Flannel | reload docker
+    - Flannel | reload docker (atomic)
     - Flannel | pause while Docker restarts
     - Flannel | wait for docker
 
@@ -26,6 +27,11 @@
   service:
     name: docker
     state: restarted
+  when: not is_atomic
+
+- name: Flannel | reload docker (atomic)
+  shell: systemctl stop docker && runc list | awk '!/ID/ {print $1}' | xargs -n 1 -I ID runc kill ID KILL && systemctl start docker
+  when: is_atomic
 
 - name: Flannel | pause while Docker restarts
   pause:


### PR DESCRIPTION
    In atomic, containers are left running when docker is restarted.
    When docker is restarted after the flannel config is put in place,
    the docker0 interface isn't re-IPed because docker sees the running
    containers and won't update the previous config.
    
    This patch kills all the running containers after docker is stopped.
    We can't simply `docker stop` the running containers, as they respawn
    before we've got a chance to stop the docker daemon, so we need to
    use runc to do this after dockerd is stopped.
