### PR TITLE
Bump calico policy controller version

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -24,7 +24,7 @@ etcd_version: v3.0.6
 # after migration to container download
 calico_version: "v1.1.0-rc8"
 calico_cni_version: "v1.5.6"
-calico_policy_version: "v0.5.2"
+calico_policy_version: "v0.5.4"
 weave_version: 1.8.2
 flannel_version: v0.6.2
 pod_infra_version: 3.0


### PR DESCRIPTION
Latest released version of kube-policy-controller
contains important bug fixes and should be used
by default.