### PR TITLE
Use hostname module to set hostname, and do it for all Os not only Co…

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-coreos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-coreos.yml
@@ -50,11 +50,3 @@
     name: "{{ item }}"
   with_items: "{{pip_python_modules}}"
 
-- name: Check configured hostname
-  shell: hostname
-  register: configured_hostname
-  check_mode: no
-
-- name: Assign inventory name to unconfigured hostnames
-  shell: sh -c "echo \"{{inventory_hostname}}\" > /etc/hostname; hostname \"{{inventory_hostname}}\""
-  when: (configured_hostname.stdout == 'localhost')

--- a/roles/bootstrap-os/tasks/main.yml
+++ b/roles/bootstrap-os/tasks/main.yml
@@ -17,3 +17,14 @@
 
 - set_fact:
     is_atomic: "{{ ostree.stat.exists }}"
+
+- name: Gather nodes hostnames
+  setup:
+    gather_subset: '!all'
+    filter: ansible_hostname
+
+- name: Assign inventory name to unconfigured hostnames
+  hostname:
+    name: "{{inventory_hostname}}"
+  when: ansible_hostname == 'localhost'
+


### PR DESCRIPTION
Currently setting ```hostname``` if it was set to ```localhost ``` was written only for CoreOs. With hostname module we can handle all systems.

cc @mattymo 