### PR TITLE
Set ClusterFirstWithHostNet for Pods with hostnetwork: true

### DIFF
--- a/roles/kubernetes-apps/ansible/tasks/netchecker.yml
+++ b/roles/kubernetes-apps/ansible/tasks/netchecker.yml
@@ -4,7 +4,7 @@
     dest: "{{kube_config_dir}}/{{item.file}}"
   with_items:
     - {file: netchecker-agent-ds.yml, type: ds, name: netchecker-agent}
-    - {file: netchecker-agent-hostnet-ds.yml, type: ds, name: netchecker-agent-hostnet}
+    - {file: netchecker-agent-hostnet-ds.j2, type: ds, name: netchecker-agent-hostnet}
     - {file: netchecker-server-pod.yml, type: po, name: netchecker-server}
     - {file: netchecker-server-svc.yml, type: svc, name: netchecker-service}
   register: manifests

--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.j2
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-hostnet-ds.j2
@@ -13,6 +13,9 @@ spec:
         app: netchecker-agent-hostnet
     spec:
       hostNetwork: True
+{%- if kube_version | version_compare('v1.6', '>=')  -%}
+      dnsPolicy: ClusterFirstWithHostNet
+{%- endif -%}
       containers:
         - name: netchecker-agent
           image: "{{ agent_img }}"

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -8,6 +8,9 @@ metadata:
     kargo: v2
 spec:
   hostNetwork: true
+{% if kube_version | version_compare('v1.6', '>=')  %}
+  dnsPolicy: ClusterFirstWithHostNet
+{% endif %}
   containers:
   - name: kube-apiserver
     image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -7,6 +7,9 @@ metadata:
     k8s-app: kube-controller
 spec:
   hostNetwork: true
+{%- if kube_version | version_compare('v1.6', '>=') -%}
+  dnsPolicy: ClusterFirstWithHostNet
+{%- endif -%}
   containers:
   - name: kube-controller-manager
     image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -7,6 +7,9 @@ metadata:
     k8s-app: kube-scheduler
 spec:
   hostNetwork: true
+{%- if kube_version | version_compare('v1.6', '>=')  -%}
+  dnsPolicy: ClusterFirstWithHostNet
+{%- endif -%}
   containers:
   - name: kube-scheduler
     image: {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }}

--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -11,6 +11,7 @@
   -v /etc/cni:/etc/cni:ro \
   -v /opt/cni:/opt/cni:ro \
   -v /etc/ssl:/etc/ssl:ro \
+  -v /etc/resolv.conf:/etc/resolv.conf \
   {% for dir in ssl_ca_dirs -%}
   -v {{ dir }}:{{ dir }}:ro \
   {% endfor -%}


### PR DESCRIPTION
    In kubernetes 1.6 ClusterFirstWithHostNet was added as an option. In
    accordance to it kubelet will generate resolv.conf based on own
    resolv.conf. However, this doesn't create 'options', thus the proper
    solution requires some investigation.

    This patch sets the same resolv.conf for kubelet as host

Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>