### PR TITLE
pin ansible to version 2.2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.2.1
+ansible==2.2.1.0
 netaddr
 # Ansible 2.2.1 requires jinja2<2.9, see <https://github.com/ansible/ansible/blob/v2.2.1.0-1/setup.py#L25>,
 # but without explicit limiting upper jinja2 version here pip ignores


### PR DESCRIPTION
ansible 2.2.2.0 has an [issue](https://github.com/ansible/ansible/issues/23016) that causes problems for kargo:

```
(env) kargo ᐅ env/bin/ansible-playbook upgrade-cluster.yml 
ERROR! Unexpected Exception: 'Host' object has no attribute 'remove_group'
```

Pinning ansible to 2.2.1.0 resolved this for me.