### PR TITLE
Fix multiline when condition in sync_certs task

### DIFF
--- a/roles/etcd/tasks/check_certs.yml
+++ b/roles/etcd/tasks/check_certs.yml
@@ -57,7 +57,7 @@
 - name: "Check_certs | Set 'sync_certs' to true"
   set_fact:
     sync_certs: true
-  when: >-
+  when: |-
       {%- set certs = {'sync': False} -%}
       {% if gen_node_certs[inventory_hostname] or
         (not etcdcert_node.results[0].stat.exists|default(False)) or


### PR DESCRIPTION
Folded style in multiline 'when' condition causes error with unexpected ident. Changing it to literal style should fix the issue.

Closes #1190