### PR TITLE
Excluding bash completion for helm on CoreOS

### DIFF
--- a/roles/kubernetes-apps/helm/tasks/main.yml
+++ b/roles/kubernetes-apps/helm/tasks/main.yml
@@ -13,4 +13,4 @@
 
 - name: Helm | Set up bash completion
   shell: "umask 022 && {{ bin_dir }}/helm completion >/etc/bash_completion.d/helm.sh"
-  when: helm_container.changed
+  when: ( helm_container.changed and not ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] )


### PR DESCRIPTION
Fixes user reported issue in slack.

CoreOS does not have `/etc/bash_completion.d`