### PR TITLE
upgrade etcd version from v3.0.6 to v3.0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Versions of supported components
 --------------------------------
 
 [kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.5.1 <br>
-[etcd](https://github.com/coreos/etcd/releases) v3.0.6 <br>
+[etcd](https://github.com/coreos/etcd/releases) v3.0.17 <br>
 [flanneld](https://github.com/coreos/flannel/releases) v0.6.2 <br>
 [calicoctl](https://github.com/projectcalico/calico-docker/releases) v0.23.0 <br>
 [canal](https://github.com/projectcalico/canal) (given calico/flannel versions) <br>

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -19,7 +19,7 @@ download_always_pull: False
 
 # Versions
 kube_version: v1.6.1
-etcd_version: v3.0.6
+etcd_version: v3.0.17
 #TODO(mattymo): Move calico versions to roles/network_plugins/calico/defaults
 # after migration to container download
 calico_version: "v1.1.0-rc8"

--- a/roles/uploads/defaults/main.yml
+++ b/roles/uploads/defaults/main.yml
@@ -2,7 +2,7 @@
 local_release_dir: /tmp
 
 # Versions
-etcd_version: v3.0.6
+etcd_version: v3.0.17
 calico_version: v0.23.0
 calico_cni_version: v1.5.6
 weave_version: v1.8.2


### PR DESCRIPTION
fix etcd bug:
cc /@mattymo

[recreate deployment can not bring the replicaset and pods(kubernetes/kubernetes 44198)](https://github.com/kubernetes/kubernetes/issues/44198)
[recreate deployment w/ same name does not work(kubernetes/kubernetes 41760)](https://github.com/kubernetes/kubernetes/issues/41760)
