### PR TITLE
Skip vault cert task evaluation when using script certs

### DIFF
--- a/roles/etcd/tasks/gen_certs_vault.yml
+++ b/roles/etcd/tasks/gen_certs_vault.yml
@@ -1,4 +1,12 @@
 ---
+- include: sync_etcd_master_certs.yml
+  when: inventory_hostname in groups.etcd
+  tags: etcd-secrets
+
+- include: sync_etcd_node_certs.yml
+  when: inventory_hostname in etcd_node_cert_hosts
+  tags: etcd-secrets
+
 
 - name: gen_certs_vault | Read in the local credentials
   command: cat /etc/vault/roles/etcd/userpass
@@ -15,7 +23,7 @@
     url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}/v1/auth/userpass/login/{{ etcd_vault_creds.username }}"
     headers:
       Accept: application/json
-      Content-Type: application/json 
+      Content-Type: application/json
     method: POST
     body_format: json
     body:
@@ -37,7 +45,7 @@
     issue_cert_copy_ca: "{{ item == etcd_master_certs_needed|first }}"
     issue_cert_file_group: "{{ etcd_cert_group }}"
     issue_cert_file_owner: kube
-    issue_cert_headers: "{{ etcd_vault_headers }}" 
+    issue_cert_headers: "{{ etcd_vault_headers }}"
     issue_cert_hosts: "{{ groups.etcd }}"
     issue_cert_ip_sans: >-
         [
@@ -60,7 +68,7 @@
     issue_cert_copy_ca: "{{ item == etcd_node_certs_needed|first }}"
     issue_cert_file_group: "{{ etcd_cert_group }}"
     issue_cert_file_owner: kube
-    issue_cert_headers: "{{ etcd_vault_headers }}" 
+    issue_cert_headers: "{{ etcd_vault_headers }}"
     issue_cert_hosts: "{{ etcd_node_cert_hosts }}"
     issue_cert_ip_sans: >-
         [
@@ -75,3 +83,5 @@
   with_items: "{{ etcd_node_certs_needed|d([]) }}"
   when: inventory_hostname in etcd_node_cert_hosts
   notify: set etcd_secret_changed
+
+

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -7,20 +7,7 @@
   when: cert_management == "script"
   tags: [etcd-secrets, facts]
 
-- include: gen_certs_script.yml
-  when: cert_management == "script"
-  tags: etcd-secrets
-
-- include: sync_etcd_master_certs.yml
-  when: cert_management == "vault" and inventory_hostname in groups.etcd
-  tags: etcd-secrets
-
-- include: sync_etcd_node_certs.yml
-  when: cert_management == "vault" and inventory_hostname in etcd_node_cert_hosts
-  tags: etcd-secrets
-
-- include: gen_certs_vault.yml
-  when: cert_management == "vault" and (etcd_master_certs_needed|d() or etcd_node_certs_needed|d())
+- include: "gen_certs_{{ cert_management }}.yml"
   tags: etcd-secrets
 
 - include: "install_{{ etcd_deployment_type }}.yml"

--- a/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_vault.yml
@@ -1,4 +1,11 @@
 ---
+- include: sync_kube_master_certs.yml
+  when: inventory_hostname in groups['kube-master']
+  tags: k8s-secrets
+
+- include: sync_kube_node_certs.yml
+  when: inventory_hostname in groups['k8s-cluster']
+  tags: k8s-secrets
 
 - name: gen_certs_vault | Read in the local credentials
   command: cat /etc/vault/roles/kube/userpass
@@ -15,7 +22,7 @@
     url: "{{ hostvars[groups.vault|first]['vault_leader_url'] }}/v1/auth/userpass/login/{{ kube_vault_creds.username }}"
     headers:
       Accept: application/json
-      Content-Type: application/json 
+      Content-Type: application/json
     method: POST
     body_format: json
     body:
@@ -54,7 +61,7 @@
         }}
     issue_cert_file_group: "{{ kube_cert_group }}"
     issue_cert_file_owner: kube
-    issue_cert_headers: "{{ kube_vault_headers }}" 
+    issue_cert_headers: "{{ kube_vault_headers }}"
     issue_cert_hosts: "{{ groups['kube-master'] }}"
     issue_cert_ip_sans: >-
         [
@@ -75,7 +82,7 @@
     issue_cert_copy_ca: "{{ item == kube_node_certs_needed|first }}"
     issue_cert_file_group: "{{ kube_cert_group }}"
     issue_cert_file_owner: kube
-    issue_cert_headers: "{{ kube_vault_headers }}" 
+    issue_cert_headers: "{{ kube_vault_headers }}"
     issue_cert_hosts: "{{ groups['k8s-cluster'] }}"
     issue_cert_path: "{{ item }}"
     issue_cert_role: kube

--- a/roles/kubernetes/secrets/tasks/main.yml
+++ b/roles/kubernetes/secrets/tasks/main.yml
@@ -74,13 +74,5 @@
 - include: "gen_certs_{{ cert_management }}.yml"
   tags: k8s-secrets
 
-- include: sync_kube_master_certs.yml
-  when: cert_management == "vault" and inventory_hostname in groups['kube-master']
-  tags: k8s-secrets
-
-- include: sync_kube_node_certs.yml
-  when: cert_management == "vault" and inventory_hostname in groups['k8s-cluster']
-  tags: k8s-secrets
-
 - include: gen_tokens.yml
   tags: k8s-secrets

--- a/roles/vault/tasks/bootstrap/start_vault_temp.yml
+++ b/roles/vault/tasks/bootstrap/start_vault_temp.yml
@@ -13,6 +13,7 @@
            -v /etc/vault:/etc/vault
            {{ vault_image_repo }}:{{ vault_version }} server
 
+#FIXME(mattymo): Crashes on first start with aufs docker storage. See hashicorp/docker-vault#19
 - name: bootstrap/start_vault_temp | Start again single node Vault with file backend
   command: docker start {{ vault_temp_container_name }}
 

--- a/roles/vault/tasks/bootstrap/start_vault_temp.yml
+++ b/roles/vault/tasks/bootstrap/start_vault_temp.yml
@@ -13,6 +13,9 @@
            -v /etc/vault:/etc/vault
            {{ vault_image_repo }}:{{ vault_version }} server
 
+- name: bootstrap/start_vault_temp | Start again single node Vault with file backend
+  command: docker start {{ vault_temp_container_name }}
+
 - name: bootstrap/start_vault_temp | Initialize vault-temp
   uri:
     url: "http://localhost:{{ vault_port }}/v1/sys/init"


### PR DESCRIPTION
At 350 node scale, such messages are in play recap, even though `cert_management == "script"`
```01:27:03 kubernetes/secrets : sync_file | Combine all possible file sync sources - 591.40s
01:27:03 kubernetes/secrets : sync_file | Combine all possible key file sync sources - 587.58s
01:27:03 kubernetes/secrets : sync_kube_node_certs | Create list of needed certs - 542.36s
01:27:03 etcd : sync_file | Combine all possible file sync sources ------------- 379.07s
01:27:03 etcd : sync_file | Combine all possible key file sync sources --------- 365.95s
01:27:03 etcd : sync_etcd_node_certs | Create list of node certs needing creation - 365.29s
```