### PR TITLE
Update kubedns-autoscaler change target

### DIFF
--- a/roles/dnsmasq/templates/dnsmasq-autoscaler.yml
+++ b/roles/dnsmasq/templates/dnsmasq-autoscaler.yml
@@ -41,7 +41,7 @@ spec:
           - /cluster-proportional-autoscaler
           - --namespace=kube-system
           - --configmap=dnsmasq-autoscaler
-          - --target=ReplicationController/dnsmasq
+          - --target=Deployment/dnsmasq
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
           # If using small nodes, "nodesPerReplica" should dominate.
           - --default-params={"linear":{"nodesPerReplica":{{ dnsmasq_nodes_per_replica }},"preventSinglePointFailure":true}}

--- a/roles/kubernetes-apps/ansible/templates/kubedns-autoscaler.yml
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-autoscaler.yml
@@ -42,7 +42,7 @@ spec:
           - --namespace=kube-system
           - --configmap=kubedns-autoscaler
           # Should keep target in sync with cluster/addons/dns/kubedns-controller.yaml.base
-          - --target=replicationcontroller/kubedns
+          - --target=Deployment/kubedns
           - --default-params={"linear":{"nodesPerReplica":{{ kubedns_nodes_per_replica }},"min":{{ kubedns_min_replicas }}}}
           - --logtostderr=true
           - --v=2


### PR DESCRIPTION
The target was a replicationcontroller but kubedns is currently a deployment