### PR TITLE
add ability for custom flags

### DIFF
--- a/docs/vars.md
+++ b/docs/vars.md
@@ -98,6 +98,20 @@ Stack](https://github.com/kubernetes-incubator/kargo/blob/master/docs/dns-stack.
   loaded by preinstall kubernetes processes.  For example, ceph and rbd backed volumes.  Set this variable to
   true to let kubelet load kernel modules.
 
+##### Custom flags for Kube Components
+For all kube components, custom flags can be passed in. This allows for edge cases where users need changes to the default deployment that may not be applicable to all deployments. This can be done by providing a list of flags. Example:
+```
+kubelet_custom_flags:
+  - "--eviction-hard=memory.available<100Mi"
+  - "--eviction-soft-grace-period=memory.available=30s"
+  - "--eviction-soft=memory.available<300Mi"
+```
+The possible vars are:
+* *apiserver_custom_flags*
+* *controller_mgr_custom_flags*
+* *scheduler_custom_flags*
+* *kubelet_custom_flags*
+
 #### User accounts
 
 Kargo sets up two Kubernetes accounts by default: ``root`` and ``kube``. Their

--- a/roles/kubernetes/master/defaults/main.yml
+++ b/roles/kubernetes/master/defaults/main.yml
@@ -51,3 +51,10 @@ kube_oidc_auth: false
 # kube_oidc_ca_file: {{ kube_cert_dir }}/ca.pem
 # kube_oidc_username_claim: sub
 # kube_oidc_groups_claim: groups
+
+##Variables for custom flags
+apiserver_custom_flags: []
+
+controller_mgr_custom_flags: []
+
+scheduler_custom_flags: []

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -83,7 +83,7 @@ spec:
 {% endif %}
 {% if apiserver_custom_flags is string %}
     - {{ apiserver_custom_flags }}
-{% else % }
+{% else %}
 {%   for flag in apiserver_custom_flags %}
     - {{ flag }}
 {%   endfor %}

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -81,9 +81,13 @@ spec:
 {% if kube_api_anonymous_auth is defined and kube_version | version_compare('v1.5', '>=')  %}
     - --anonymous-auth={{ kube_api_anonymous_auth }}
 {% endif %}
-{% for flag in apiserver_custom_flags %}
+{% if apiserver_custom_flags is string %}
+    - {{ apiserver_custom_flags }}
+{% else % }
+{%   for flag in apiserver_custom_flags %}
     - {{ flag }}
-{% endfor %}
+{%   endfor %}
+{% endif %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -81,6 +81,9 @@ spec:
 {% if kube_api_anonymous_auth is defined and kube_version | version_compare('v1.5', '>=')  %}
     - --anonymous-auth={{ kube_api_anonymous_auth }}
 {% endif %}
+{% for flag in apiserver_custom_flags %}
+    - {{ flag }}
+{% endfor %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -46,9 +46,13 @@ spec:
     - --configure-cloud-routes=true
     - --cluster-cidr={{ kube_pods_subnet }}
 {% endif %}
-{% for flag in controller_mgr_custom_flags %}
+{% if controller_mgr_custom_flags is string %}
+    - {{ controller_mgr_custom_flags }}
+{% else % }
+{%   for flag in controller_mgr_custom_flags %}
     - {{ flag }}
-{% endfor %}
+{%   endfor %}
+{% endif %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -46,6 +46,9 @@ spec:
     - --configure-cloud-routes=true
     - --cluster-cidr={{ kube_pods_subnet }}
 {% endif %}
+{% for flag in controller_mgr_custom_flags %}
+    - {{ flag }}
+{% endfor %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -48,7 +48,7 @@ spec:
 {% endif %}
 {% if controller_mgr_custom_flags is string %}
     - {{ controller_mgr_custom_flags }}
-{% else % }
+{% else %}
 {%   for flag in controller_mgr_custom_flags %}
     - {{ flag }}
 {%   endfor %}

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -29,7 +29,7 @@ spec:
     - --v={{ kube_log_level }}
 {% if scheduler_custom_flags is string %}
     - {{ scheduler_custom_flags }}
-{% else % }
+{% else %}
 {%   for flag in scheduler_custom_flags %}
     - {{ flag }}
 {%   endfor %}

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -27,6 +27,9 @@ spec:
     - --leader-elect=true
     - --master={{ kube_apiserver_endpoint }}
     - --v={{ kube_log_level }}
+{% for flag in scheduler_custom_flags %}
+    - {{ flag }}
+{% endfor %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -27,9 +27,13 @@ spec:
     - --leader-elect=true
     - --master={{ kube_apiserver_endpoint }}
     - --v={{ kube_log_level }}
-{% for flag in scheduler_custom_flags %}
+{% if scheduler_custom_flags is string %}
+    - {{ scheduler_custom_flags }}
+{% else % }
+{%   for flag in scheduler_custom_flags %}
     - {{ flag }}
-{% endfor %}
+{%   endfor %}
+{% endif %}
     livenessProbe:
       httpGet:
         host: 127.0.0.1

--- a/roles/kubernetes/node/defaults/main.yml
+++ b/roles/kubernetes/node/defaults/main.yml
@@ -45,3 +45,6 @@ etcd_config_dir: /etc/ssl/etcd
 kube_apiserver_node_port_range: "30000-32767"
 
 kubelet_load_modules: false
+
+##Support custom flags to be passed to kubelet
+kubelet_custom_flags: []

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -44,7 +44,7 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 {%   set node_labels %}--node-labels=node-role.kubernetes.io/node=true{% endset %}
 {% endif %}
 
-KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kubelet_args_kubeconfig }} {{ node_labels }} {% if kubelet_custom_flags is string %}{{kubelet_custom_flags}}{% else %}{% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}{% endif %}"
+KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kubelet_args_kubeconfig }} {{ node_labels }} {% if kubelet_custom_flags is string %} {{kubelet_custom_flags}} {% else %}{% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}{% endif %}"
 {% if kube_network_plugin is defined and kube_network_plugin in ["calico", "weave", "canal"] %}
 KUBELET_NETWORK_PLUGIN="--network-plugin=cni --network-plugin-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 {% elif kube_network_plugin is defined and kube_network_plugin == "weave" %}

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -44,7 +44,7 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 {%   set node_labels %}--node-labels=node-role.kubernetes.io/node=true{% endset %}
 {% endif %}
 
-KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kubelet_args_kubeconfig }} {{ node_labels }} {% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}"
+KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kubelet_args_kubeconfig }} {{ node_labels }} {% if kubelet_custom_flags is string %}{{kubelet_custom_flags}}{% else %}{% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}{% endif %}"
 {% if kube_network_plugin is defined and kube_network_plugin in ["calico", "weave", "canal"] %}
 KUBELET_NETWORK_PLUGIN="--network-plugin=cni --network-plugin-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 {% elif kube_network_plugin is defined and kube_network_plugin == "weave" %}

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -44,7 +44,7 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 {%   set node_labels %}--node-labels=node-role.kubernetes.io/node=true{% endset %}
 {% endif %}
 
-KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kubelet_args_kubeconfig }} {{ node_labels }}"
+KUBELET_ARGS="{{ kubelet_args_base }} {{ kubelet_args_dns }} {{ kubelet_args_kubeconfig }} {{ node_labels }} {% for flag in kubelet_custom_flags %} {{flag}} {% endfor %}"
 {% if kube_network_plugin is defined and kube_network_plugin in ["calico", "weave", "canal"] %}
 KUBELET_NETWORK_PLUGIN="--network-plugin=cni --network-plugin-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 {% elif kube_network_plugin is defined and kube_network_plugin == "weave" %}


### PR DESCRIPTION
This addresses #899, as well as possibly addressing #1193. Would provide a good way to add flags that are more specific to a cluster's environment and size, but not useful for everyone.