### PR TITLE
Explicitly create cni bin dir

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -7,6 +7,12 @@
 - include: pre_upgrade.yml
   tags: kubelet
 
+- name: Ensure /var/lib/cni exists
+  file:
+    path: /var/lib/cni
+    state: directory
+    mode: 0755
+
 - include: install.yml
   tags: kubelet
 


### PR DESCRIPTION
If this path doesnt exist, it will cause kubelet to fail to start when
using rkt ( whereas when using docker for kubelet, docker automatically
creates paths that do not exist )