### PR TITLE
Fix restart kube-controller

### DIFF
--- a/roles/kubernetes/preinstall/handlers/main.yml
+++ b/roles/kubernetes/preinstall/handlers/main.yml
@@ -45,5 +45,5 @@
   when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf'
 
 - name: Preinstall | restart kube-controller-manager
-  shell: "docker ps -f name=k8s-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
+  shell: "docker ps -f name=k8s_kube-controller-manager* -q | xargs --no-run-if-empty docker rm -f"
   when: inventory_hostname in groups['kube-master'] and dns_mode != 'none' and resolvconf_mode == 'host_resolvconf' and kube_controller_set.stat.exists


### PR DESCRIPTION
kubernetesUnitPrefix was changed to k8s_* in 1.5. This patch reflects
this change in kargo