### PR TITLE
Use ClusterFirstWithHostNet only when not dns_early

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -7,7 +7,7 @@ metadata:
     k8s-app: kube-controller
 spec:
   hostNetwork: true
-{% if kube_version | version_compare('v1.6', '>=') %}
+{% if kube_version | version_compare('v1.6', '>=') and not dns_early|bool %}
   dnsPolicy: ClusterFirstWithHostNet
 {% endif %}
   containers:


### PR DESCRIPTION
On early stage we'll use default DNS policy. Then we'll use
ClusterFirstWithHostNet policy once dnsmasq is set up

Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>