### PR TITLE
Change DNS policy for kubernetes components

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -9,7 +9,7 @@ metadata:
 spec:
   hostNetwork: true
 {% if kube_version | version_compare('v1.6', '>=')  %}
-  dnsPolicy: ClusterFirstWithHostNet
+  dnsPolicy: ClusterFirst
 {% endif %}
   containers:
   - name: kube-apiserver

--- a/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-controller-manager.manifest.j2
@@ -8,7 +8,7 @@ metadata:
 spec:
   hostNetwork: true
 {% if kube_version | version_compare('v1.6', '>=') %}
-  dnsPolicy: ClusterFirstWithHostNet
+  dnsPolicy: ClusterFirst
 {% endif %}
   containers:
   - name: kube-controller-manager

--- a/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-scheduler.manifest.j2
@@ -8,7 +8,7 @@ metadata:
 spec:
   hostNetwork: true
 {% if kube_version | version_compare('v1.6', '>=') %}
-  dnsPolicy: ClusterFirstWithHostNet
+  dnsPolicy: ClusterFirst
 {% endif %}
   containers:
   - name: kube-scheduler

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -8,7 +8,7 @@ metadata:
 spec:
   hostNetwork: true
 {% if kube_version | version_compare('v1.6', '>=') %}
-  dnsPolicy: ClusterFirstWithHostNet
+  dnsPolicy: ClusterFirst
 {% endif %}
   containers:
   - name: kube-proxy

--- a/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
+++ b/roles/kubernetes/preinstall/tasks/set_resolv_facts.yml
@@ -16,7 +16,7 @@
       {{dns_domain}}.{{d}}./{{d}}.{{d}}./com.{{d}}./
       {%- endfor %}
     default_resolver: >-
-      {%- if cloud_provider is defined and cloud_provider == 'gce' -%}169.254.169.254{%- else -%}8.8.8.8{%- endif -%}
+      {%- if cloud_provider is defined and cloud_provider in [ 'gce', 'aws' ] -%}169.254.169.254{%- else -%}8.8.8.8{%- endif -%}
 
 - name: check if kubelet is configured
   stat:


### PR DESCRIPTION
According to code apiserver, scheduler, controller-manager don't use
resolution of objects they created. It's not harmful to change policy to
have external resolver.

Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>