### PR TITLE
bootstrap task on centos missing packages

### DIFF
--- a/roles/bootstrap-os/tasks/bootstrap-centos.yml
+++ b/roles/bootstrap-os/tasks/bootstrap-centos.yml
@@ -13,3 +13,15 @@
     line: "enabled=0"
     state: present
   when: fastestmirror.stat.exists
+
+- name: Install packages requirements for bootstrap
+  action:
+    module: "{{ ansible_pkg_mgr }}"
+    name: "{{ item }}"
+    state: latest
+  register: bs_pkgs_task_result
+  until: bs_pkgs_task_result|succeeded
+  retries: 4
+  delay: "{{ retry_stagger | random + 3 }}"
+  with_items: "libselinux-python"
+


### PR DESCRIPTION
For my test environment on GCE, the centos image I use doesn't have the selinux python
bindings installed.  These do get installed in kubernetes-preinstall, but the bootstrap sudo
tty line fix-up needs it as well.  This causes the playbook to fail in that environment.

This adds the explicit install of the bindings before the tty call.