### PR TITLE
Add support for different tags for netcheck containers

### DIFF
--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -59,9 +59,11 @@ hyperkube_image_repo: "quay.io/coreos/hyperkube"
 hyperkube_image_tag: "{{ kube_version }}_coreos.0"
 pod_infra_image_repo: "gcr.io/google_containers/pause-amd64"
 pod_infra_image_tag: "{{ pod_infra_version }}"
-netcheck_tag: "v1.0"
+netcheck_version: "v1.0"
 netcheck_agent_img_repo: "quay.io/l23network/k8s-netchecker-agent"
+netcheck_agent_tag: "{{ netcheck_version }}"
 netcheck_server_img_repo: "quay.io/l23network/k8s-netchecker-server"
+netcheck_server_tag: "{{ netcheck_version }}"
 weave_kube_image_repo: "weaveworks/weave-kube"
 weave_kube_image_tag: "{{ weave_version }}"
 weave_npc_image_repo: "weaveworks/weave-npc"
@@ -101,13 +103,13 @@ downloads:
   netcheck_server:
     container: true
     repo: "{{ netcheck_server_img_repo }}"
-    tag: "{{ netcheck_tag }}"
+    tag: "{{ netcheck_server_tag }}"
     sha256: "{{ netcheck_server_digest_checksum|default(None) }}"
     enabled: "{{ deploy_netchecker|bool }}"
   netcheck_agent:
     container: true
     repo: "{{ netcheck_agent_img_repo }}"
-    tag: "{{ netcheck_tag }}"
+    tag: "{{ netcheck_agent_tag }}"
     sha256: "{{ netcheck_agent_digest_checksum|default(None) }}"
     enabled: "{{ deploy_netchecker|bool }}"
   etcd:

--- a/roles/kubernetes-apps/ansible/defaults/main.yml
+++ b/roles/kubernetes-apps/ansible/defaults/main.yml
@@ -24,8 +24,8 @@ deploy_netchecker: false
 netchecker_port: 31081
 agent_report_interval: 15
 netcheck_namespace: default
-agent_img: "{{ netcheck_agent_img_repo }}:{{ netcheck_tag }}"
-server_img: "{{ netcheck_server_img_repo }}:{{ netcheck_tag }}"
+agent_img: "{{ netcheck_agent_img_repo }}:{{ netcheck_agent_tag }}"
+server_img: "{{ netcheck_server_img_repo }}:{{ netcheck_server_tag }}"
 
 # Limits for netchecker apps
 netchecker_agent_cpu_limit: 30m


### PR DESCRIPTION
Replace 'netcheck_tag' with 'netcheck_version' and add additional 'netcheck_server_tag' and 'netcheck_agent_tag' config options (defaults to 'netcheck_version')  to provide ability to use different tags for server and agent containers.