### PR TITLE
add MY_NODE_NAME variable into netchecker-agent environment

### DIFF
--- a/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml
+++ b/roles/kubernetes-apps/ansible/templates/netchecker-agent-ds.yml
@@ -20,6 +20,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           args:
             - "-v=5"
             - "-alsologtostderr=true"


### PR DESCRIPTION
Now, netchecker-agent needs to know its node name to report it to the server (it should be used for metrics).
So, adding a corresponding variable into daemonset template.