### PR TITLE
mount os-release to ensure the node's OS is what's seen in k8s api

### DIFF
--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -25,6 +25,7 @@
   -v /var/lib/cni:/var/lib/cni:shared \
   -v /var/run:/var/run:rw \
   -v {{kube_config_dir}}:{{kube_config_dir}}:ro \
+  -v /etc/os-release:/etc/os-release \
   {{ hyperkube_image_repo }}:{{ hyperkube_image_tag}} \
   ./hyperkube kubelet \
   "$@"

--- a/roles/kubernetes/node/templates/kubelet-container.j2
+++ b/roles/kubernetes/node/templates/kubelet-container.j2
@@ -25,7 +25,7 @@
   -v /var/lib/cni:/var/lib/cni:shared \
   -v /var/run:/var/run:rw \
   -v {{kube_config_dir}}:{{kube_config_dir}}:ro \
-  -v /etc/os-release:/etc/os-release \
+  -v /etc/os-release:/etc/os-release:ro \
   {{ hyperkube_image_repo }}:{{ hyperkube_image_tag}} \
   ./hyperkube kubelet \
   "$@"

--- a/roles/kubernetes/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.rkt.service.j2
@@ -20,7 +20,7 @@ ExecStartPre=-/bin/mkdir -p /var/lib/kubelet
 EnvironmentFile={{kube_config_dir}}/kubelet.env
 # stage1-fly mounts /proc /sys /dev so no need to duplicate the mounts
 ExecStart=/usr/bin/rkt run \
-        --volume os-release,kind=host,source=/etc/os-release \
+        --volume os-release,kind=host,source=/etc/os-release,readOnly=true \
         --volume dns,kind=host,source=/etc/resolv.conf \
         --volume etc-kubernetes,kind=host,source={{ kube_config_dir }},readOnly=false \
         --volume etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \

--- a/roles/kubernetes/node/templates/kubelet.rkt.service.j2
+++ b/roles/kubernetes/node/templates/kubelet.rkt.service.j2
@@ -20,6 +20,7 @@ ExecStartPre=-/bin/mkdir -p /var/lib/kubelet
 EnvironmentFile={{kube_config_dir}}/kubelet.env
 # stage1-fly mounts /proc /sys /dev so no need to duplicate the mounts
 ExecStart=/usr/bin/rkt run \
+        --volume os-release,kind=host,source=/etc/os-release \
         --volume dns,kind=host,source=/etc/resolv.conf \
         --volume etc-kubernetes,kind=host,source={{ kube_config_dir }},readOnly=false \
         --volume etc-ssl-certs,kind=host,source=/etc/ssl/certs,readOnly=true \
@@ -39,6 +40,7 @@ ExecStart=/usr/bin/rkt run \
         --mount volume=opt-cni,target=/opt/cni \
         --mount volume=var-lib-cni,target=/var/lib/cni \
 {% endif %}
+        --mount volume=os-release,target=/etc/os-release \
         --mount volume=dns,target=/etc/resolv.conf \
         --mount volume=etc-kubernetes,target={{ kube_config_dir }} \
         --mount volume=etc-ssl-certs,target=/etc/ssl/certs \


### PR DESCRIPTION
Somewhere along the way, the way that we're using the kubelet container changed its behavior to no longer show the host's OS in kubernetes instead of the OS of the container that kubelet is running in. We use this info found in `kubectl describe node $NODENAME` for some dashboarding and monitoring internally. This also seems to be an issue seen by the CoreOS guys some time ago and fixed. This should take care of it for our environment.

More info: https://github.com/coreos/coreos-kubernetes/issues/399