### PR TITLE
Update Readme with Kubernetes and Docker Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Note: Upstart/SysV init based OS types are not supported.
 Versions of supported components
 --------------------------------
 
-[kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.5.1 <br>
+[kubernetes](https://github.com/kubernetes/kubernetes/releases) v1.6.1 <br>
 [etcd](https://github.com/coreos/etcd/releases) v3.0.6 <br>
 [flanneld](https://github.com/coreos/flannel/releases) v0.6.2 <br>
 [calicoctl](https://github.com/projectcalico/calico-docker/releases) v0.23.0 <br>
 [canal](https://github.com/projectcalico/canal) (given calico/flannel versions) <br>
 [weave](http://weave.works/) v1.8.2 <br>
-[docker](https://www.docker.com/) v1.12.5 <br>
+[docker](https://www.docker.com/) v1.13.1 <br>
 [rkt](https://coreos.com/rkt/docs/latest/) v1.21.0 <br>
 
 Note: rkt support as docker alternative is limited to control plane (etcd and


### PR DESCRIPTION
- Current Kubernetes version that Kargo deploying is 1.6.1
- Current Docker version that Kargo deploying is 1.13.1