### PR TITLE
default to kubedns &set nxdomain in kubedns deployment if that's the dns_mode

### DIFF
--- a/inventory/group_vars/k8s-cluster.yml
+++ b/inventory/group_vars/k8s-cluster.yml
@@ -98,7 +98,7 @@ cluster_name: cluster.local
 # Subdomains of DNS domain to be resolved via /etc/resolv.conf for hostnet pods
 ndots: 2
 # Can be dnsmasq_kubedns, kubedns or none
-dns_mode: dnsmasq_kubedns
+dns_mode: kubedns
 # Can be docker_dns, host_resolvconf or none
 resolvconf_mode: docker_dns
 # Deploy netchecker app to verify DNS resolve as an HTTP service

--- a/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml
@@ -83,6 +83,9 @@ spec:
 {% if kube_log_level == '4' %}
         - --log-queries
 {% endif %}
+{% if dns_mode == 'kubedns' %}
+        - --local=/{{ bogus_domains }}
+{% endif %}
         ports:
         - containerPort: 53
           name: dns

--- a/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml
+++ b/roles/kubernetes-apps/ansible/templates/kubedns-deploy.yml
@@ -83,9 +83,7 @@ spec:
 {% if kube_log_level == '4' %}
         - --log-queries
 {% endif %}
-{% if dns_mode == 'kubedns' %}
         - --local=/{{ bogus_domains }}
-{% endif %}
         ports:
         - containerPort: 53
           name: dns


### PR DESCRIPTION
This simply changes the default dns after some discussion in the slack channel. Also applies the bogus domain fixes to the kubedns deployment if it's the only dns being deployed.