### PR TITLE
Minor kubelet updates

### DIFF
--- a/roles/kargo-defaults/defaults/main.yaml
+++ b/roles/kargo-defaults/defaults/main.yaml
@@ -42,9 +42,6 @@ kube_script_dir: "{{ bin_dir }}/kubernetes-scripts"
 kube_manifest_dir: "{{ kube_config_dir }}/manifests"
 system_namespace: kube-system
 
-# Logging directory (sysvinit systems)
-kube_log_dir: "/var/log/kubernetes"
-
 # This is where all the cert scripts and certs will be located
 kube_cert_dir: "{{ kube_config_dir }}/ssl"
 

--- a/roles/kubernetes/node/templates/kubelet.j2
+++ b/roles/kubernetes/node/templates/kubelet.j2
@@ -19,13 +19,13 @@ KUBELET_HOSTNAME="--hostname-override={{ ansible_hostname }}"
 
 {# DNS settings for kubelet #}
 {% if dns_mode == 'kubedns' %}
-{% set kubelet_args_cluster_dns %}--cluster_dns={{ skydns_server }}{% endset %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ skydns_server }}{% endset %}
 {% elif dns_mode == 'dnsmasq_kubedns' %}
-{% set kubelet_args_cluster_dns %}--cluster_dns={{ dns_server }}{% endset %}
+{% set kubelet_args_cluster_dns %}--cluster-dns={{ dns_server }}{% endset %}
 {% else %}
 {% set kubelet_args_cluster_dns %}{% endset %}
 {% endif %}
-{% set kubelet_args_dns %}{{ kubelet_args_cluster_dns }} --cluster_domain={{ dns_domain }} --resolv-conf={{ kube_resolv_conf }}{% endset %}
+{% set kubelet_args_dns %}{{ kubelet_args_cluster_dns }} --cluster-domain={{ dns_domain }} --resolv-conf={{ kube_resolv_conf }}{% endset %}
 
 {# Location of the apiserver #}
 {% set kubelet_args_kubeconfig %}--kubeconfig={{ kube_config_dir}}/node-kubeconfig.yaml --require-kubeconfig{% endset %}


### PR DESCRIPTION
Not sure if these flags were deprecated at some point, but current docs+code show that these flags should have hyphens in them, not underscores. 

https://kubernetes.io/docs/admin/kubelet/
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/options/options.go#L219
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/options/options.go#L222