### PR TITLE
adding --skip-exists flag for peer_with_router

### DIFF
--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -219,7 +219,7 @@
    "apiVersion": "v1",
    "metadata": {"node": "{{ inventory_hostname }}", "scope": "node", "peerIP": "{{ item.router_id }}"}
    }'
-   | {{ bin_dir }}/calicoctl create -f -
+   | {{ bin_dir }}/calicoctl create --skip-exists -f -
   with_items: "{{ peers|default([]) }}"
   when: (not legacy_calicoctl and
          peer_with_router|default(false) and inventory_hostname in groups['k8s-cluster'])


### PR DESCRIPTION
Fixes #1308 

- adds `skip-exists` flag to `Configure peering with router(s)` so that subsequent runs do not fail.
