### PR TITLE
add direct path for cert in AWS with RHEL family

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -105,6 +105,11 @@ spec:
     - mountPath: {{ etcd_cert_dir }}
       name: etcd-certs
       readOnly: true
+{% if cloud_provider == 'aws' and ansible_os_family == 'RedHat' %}
+    - mountPath: /etc/ssl/certs/ca-bundle.crt
+      name: rhel-ca-bundle
+      readOnly: true
+{% endif %}
   volumes:
   - hostPath:
       path: {{ kube_config_dir }}
@@ -115,3 +120,8 @@ spec:
   - hostPath:
       path: {{ etcd_cert_dir }}
     name: etcd-certs
+{% if cloud_provider == 'aws' and ansible_os_family == 'RedHat' %}
+  - hostPath:
+      path: /etc/ssl/certs/ca-bundle.crt
+    name: rhel-ca-bundle
+{% endif %}


### PR DESCRIPTION
resolves #1143. I've been able to reproduce on AWS and can also confirm that this cert gets mounted just fine in my openstack environment. Unsure why we see this only in AWS, but this does indeed seem to fix it.