### PR TITLE
Additional checks for ansible dry-run (--check) mode

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -61,11 +61,12 @@
     force: "{{item.force|default(omit)}}"
     state: present
   register: docker_task_result
-  until: docker_task_result|succeeded
+  until: docker_task_result|succeeded or ansible_check_mode
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   with_items: "{{ docker_package_info.pkgs }}"
   notify: restart docker
+  ignore_errors: "{{ ansible_check_mode }}"
   when: not (ansible_os_family in ["CoreOS", "Container Linux by CoreOS"] or is_atomic) and (docker_package_info.pkgs|length > 0)
 
 - name: check minimum docker version for docker_dns mode. You need at least docker version >= 1.12 for resolvconf_mode=docker_dns
@@ -85,3 +86,4 @@
     state: started
   with_items:
     - docker
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/etcd/tasks/gen_certs_script.yml
+++ b/roles/etcd/tasks/gen_certs_script.yml
@@ -127,6 +127,7 @@
     dest: "{{cert_tempfile.stdout}}"                                            
     owner: root                                                                 
     mode: "0600"                                                                
+  ignore_errors: "{{ ansible_check_mode }}"
   when: inventory_hostname in groups['etcd'] and sync_certs|default(false) and
         inventory_hostname != groups['etcd'][0]
 
@@ -135,6 +136,7 @@
   no_log: true
   changed_when: false
   check_mode: no
+  ignore_errors: "{{ ansible_check_mode }}"
   when: inventory_hostname in groups['etcd'] and sync_certs|default(false) and
         inventory_hostname != groups['etcd'][0]
   notify: set secret_changed
@@ -143,6 +145,7 @@
   file:
     path: "{{cert_tempfile.stdout}}"
     state: absent
+  ignore_errors: "{{ ansible_check_mode }}"
   when: inventory_hostname in groups['etcd'] and sync_certs|default(false) and
         inventory_hostname != groups['etcd'][0]
 
@@ -181,6 +184,7 @@
     dest: "{{ ca_cert_path }}"
     remote_src: true
   register: etcd_ca_cert
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Gen_certs | update ca-certificates (Debian/Ubuntu/Container Linux by CoreOS)
   command: update-ca-certificates

--- a/roles/etcd/tasks/install_docker.yml
+++ b/roles/etcd/tasks/install_docker.yml
@@ -11,6 +11,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
+  ignore_errors: "{{ ansible_check_mode }}"
 
 #Plan B: looks nicer, but requires docker-py on all hosts:
 #- name: Install | Set up etcd-binarycopy container

--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -36,6 +36,7 @@
     name: etcd
     state: started
     enabled: yes
+  ignore_errors: "{{ ansible_check_mode }}"
   when: is_etcd_master and etcd_cluster_setup
 
 # After etcd cluster is assembled, make sure that

--- a/roles/etcd/tasks/pre_upgrade.yml
+++ b/roles/etcd/tasks/pre_upgrade.yml
@@ -34,6 +34,7 @@
 - name: "Pre-upgrade | remove etcd-proxy if it exists"
   command: "{{ docker_bin_dir }}/docker rm -f {{item}}"
   with_items: "{{etcd_proxy_container.stdout_lines}}"
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "Pre-upgrade | see if etcdctl is installed"
   stat:
@@ -45,11 +46,12 @@
   register: etcd_member_list
   retries: 10
   delay: 3
-  until: etcd_member_list.rc != 2
+  until: etcd_member_list.rc != 2 or ansible_check_mode
   run_once: true
   when: etcdctl_installed.stat.exists
   changed_when: false
   failed_when: false
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: "Pre-upgrade | change peer names to SSL"
   shell: >-
@@ -57,3 +59,4 @@
     awk -F"[: =]" '{print "{{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses | regex_replace('https','http') }} member update "$1" https:"$7":"$8}' | bash
   run_once: true
   when: 'etcdctl_installed.stat.exists and etcd_member_list.rc == 0 and "http://" in etcd_member_list.stdout'
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/kubernetes-apps/ansible/tasks/main.yml
+++ b/roles/kubernetes-apps/ansible/tasks/main.yml
@@ -4,6 +4,7 @@
     url: http://localhost:8080/healthz
   register: result
   until: result.status == 200
+  ignore_errors: "{{ ansible_check_mode }}"
   retries: 10
   delay: 6
   when: inventory_hostname == groups['kube-master'][0]

--- a/roles/kubernetes/master/handlers/main.yml
+++ b/roles/kubernetes/master/handlers/main.yml
@@ -28,6 +28,7 @@
   until: scheduler_result.status == 200
   retries: 60
   delay: 5
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Master | wait for kube-controller-manager
   uri:
@@ -36,6 +37,7 @@
   until: controller_manager_result.status == 200
   retries: 15
   delay: 5
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Master | wait for the apiserver to be running
   uri:
@@ -44,3 +46,4 @@
   until: result.status == 200
   retries: 20
   delay: 6
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -5,6 +5,7 @@
 - name: Copy kubectl from hyperkube container
   command: "{{ docker_bin_dir }}/docker run --rm -v {{ bin_dir }}:/systembindir {{ hyperkube_image_repo }}:{{ hyperkube_image_tag }} /bin/cp /hyperkube /systembindir/kubectl"
   register: kube_task_result
+  ignore_errors: "{{ ansible_check_mode }}"
   until: kube_task_result.rc == 0
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
@@ -23,6 +24,7 @@
     group: root
     mode: 0755
   when: ansible_os_family in ["Debian","RedHat"]
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: [kubectl, upgrade]
 
 - name: Write kube-apiserver manifest

--- a/roles/kubernetes/master/tasks/pre-upgrade.yml
+++ b/roles/kubernetes/master/tasks/pre-upgrade.yml
@@ -45,7 +45,7 @@
 - name: "Pre-upgrade | etcd3 upgrade | use etcd2 unless forced to etc3"
   set_fact:
     kube_apiserver_storage_backend: "etcd2"
-  when: old_data_exists.rc == 0 and not force_etcd3|bool
+  when: not old_data_exists|skipped and old_data_exists.rc == 0 and not force_etcd3|bool
 
 - name: "Pre-upgrade | etcd3 upgrade | see if data was already migrated"
   command: "{{ bin_dir }}/etcdctl --endpoints={{ etcd_access_addresses }} get --limit=1 --prefix=true /registry/minions"

--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -60,4 +60,5 @@
     name: kubelet
     enabled: yes
     state: started
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: kubelet

--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -83,6 +83,7 @@
   no_log: true
   register: master_cert_data
   check_mode: no
+  ignore_errors: "{{ ansible_check_mode }}"
   delegate_to: "{{groups['kube-master'][0]}}"
   when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]
@@ -115,6 +116,7 @@
     dest: "{{cert_tempfile.stdout}}"
     owner: root
     mode: "0600"
+  ignore_errors: "{{ ansible_check_mode }}"
   when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]
 
@@ -123,6 +125,7 @@
   no_log: true
   changed_when: false
   check_mode: no
+  ignore_errors: "{{ ansible_check_mode }}"
   when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]
   notify: set secret_changed
@@ -131,6 +134,7 @@
   file:
     path: "{{cert_tempfile.stdout}}"
     state: absent
+  ignore_errors: "{{ ansible_check_mode }}"
   when: inventory_hostname in groups['kube-master'] and sync_certs|default(false) and
         inventory_hostname != groups['kube-master'][0]
 
@@ -153,6 +157,7 @@
     owner: kube
     mode: "u=rwX,g-rwx,o-rwx"
     recurse: yes
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Gen_certs | target ca-certificates path
   set_fact:
@@ -172,6 +177,7 @@
     dest: "{{ ca_cert_path }}"
     remote_src: true
   register: kube_ca_cert
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Gen_certs | update ca-certificates (Debian/Ubuntu/Container Linux by CoreOS)
   command: update-ca-certificates

--- a/roles/kubernetes/secrets/tasks/gen_tokens.yml
+++ b/roles/kubernetes/secrets/tasks/gen_tokens.yml
@@ -40,6 +40,7 @@
   shell: "(find {{ kube_token_dir }} -maxdepth 1 -type f)"
   register: tokens_list
   check_mode: no
+  ignore_errors: "{{ ansible_check_mode }}"
   delegate_to: "{{groups['kube-master'][0]}}"
   run_once: true
   when: sync_tokens|default(false)
@@ -48,11 +49,13 @@
   shell: "tar cfz - {{ tokens_list.stdout_lines | join(' ') }} | base64 --wrap=0"
   register: tokens_data
   check_mode: no
+  ignore_errors: "{{ ansible_check_mode }}"
   delegate_to: "{{groups['kube-master'][0]}}"
   run_once: true
   when: sync_tokens|default(false)
 
 - name: Gen_tokens | Copy tokens on masters
   shell: "echo '{{ tokens_data.stdout|quote }}' | base64 -d | tar xz -C /"
+  ignore_errors: "{{ ansible_check_mode }}"
   when: inventory_hostname in groups['kube-master'] and sync_tokens|default(false) and
         inventory_hostname != groups['kube-master'][0]

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -47,6 +47,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: [hyperkube, upgrade]
 
 - name: Calico | Copy cni plugins from calico/cni container
@@ -56,6 +57,7 @@
   retries: 4
   delay: "{{ retry_stagger | random + 3 }}"
   changed_when: false
+  ignore_errors: "{{ ansible_check_mode }}"
   when: overwrite_hyperkube_cni|bool
   tags: [hyperkube, upgrade]
 
@@ -77,6 +79,7 @@
   delay: 5
   delegate_to: "{{groups['etcd'][0]}}"
   run_once: true
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Calico | Check if calico network pool has already been configured
   command: |-
@@ -103,6 +106,7 @@
   environment:
     NO_DEFAULT_POOLS: true
   run_once: true
+  ignore_errors: "{{ ansible_check_mode }}"
   when: not legacy_calicoctl and
          ("Key not found" in calico_conf.stdout or "nodes" not in calico_conf.stdout)
 
@@ -151,11 +155,13 @@
 - set_fact:
     calico_pools: "{{ calico_pools_raw.stdout | from_json }}"
   run_once: true
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Calico | Check if calico pool is properly configured
   fail:
     msg: 'Only one network pool must be configured and it must be the subnet {{ kube_pods_subnet }}.
     Please erase calico configuration and run the playbook again ("etcdctl rm --recursive /calico/v1/ipam/v4/pool")'
+  ignore_errors: "{{ ansible_check_mode }}"
   when: ( calico_pools['node']['nodes'] | length > 1 ) or
         ( not calico_pools['node']['nodes'][0]['key'] | search(".*{{ kube_pods_subnet | ipaddr('network') }}.*") )
   run_once: true
@@ -203,6 +209,7 @@
     name: calico-node
     state: started
     enabled: yes
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Calico | Disable node mesh
   shell: "{{ bin_dir }}/calicoctl config set nodeToNodeMesh off"


### PR DESCRIPTION
Hi, ansible '--check' mode is currently broken, additional check were needed to fix it before/after playbook apply.
It would be nice to have dry-run checks in CI before/after playbook apply.
Best regards.