### PR TITLE
check if cloud_provider is defined

### DIFF
--- a/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
+++ b/roles/kubernetes/master/templates/manifests/kube-apiserver.manifest.j2
@@ -105,7 +105,7 @@ spec:
     - mountPath: {{ etcd_cert_dir }}
       name: etcd-certs
       readOnly: true
-{% if cloud_provider == 'aws' and ansible_os_family == 'RedHat' %}
+{% if cloud_provider is defined and cloud_provider == 'aws' and ansible_os_family == 'RedHat' %}
     - mountPath: /etc/ssl/certs/ca-bundle.crt
       name: rhel-ca-bundle
       readOnly: true
@@ -120,7 +120,7 @@ spec:
   - hostPath:
       path: {{ etcd_cert_dir }}
     name: etcd-certs
-{% if cloud_provider == 'aws' and ansible_os_family == 'RedHat' %}
+{% if cloud_provider is defined and cloud_provider == 'aws' and ansible_os_family == 'RedHat' %}
   - hostPath:
       path: /etc/ssl/certs/ca-bundle.crt
     name: rhel-ca-bundle


### PR DESCRIPTION
I introduced a bug with bare metal nodes when I provided the RHEL-family cert fix. We need to check that cloud_provider exists at all before looking at its value. Mentioned by @aquavitae here: https://github.com/kubernetes-incubator/kargo/commit/7e2aafcc76cbda082cfe50973bd8164227289ac5#commitcomment-22342145