### PR TITLE
Support provisioning vagrant k8s clusters with coreos

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,10 +7,12 @@ Vagrant.require_version ">= 1.8.0"
 
 CONFIG = File.join(File.dirname(__FILE__), "vagrant/config.rb")
 
+COREOS_URL_TEMPLATE = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json"
+
 SUPPORTED_OS = {
-  "coreos-stable" => {box: "coreos-stable",      bootstrap_os: "coreos", user: "core"},
-  "coreos-alpha"  => {box: "coreos-alpha",       bootstrap_os: "coreos", user: "core"},
-  "coreos-beta"   => {box: "coreos-beta",        bootstrap_os: "coreos", user: "core"},
+  "coreos-stable" => {box: "coreos-stable",      bootstrap_os: "coreos", user: "core", box_url: COREOS_URL_TEMPLATE % ["stable"]},
+  "coreos-alpha"  => {box: "coreos-alpha",       bootstrap_os: "coreos", user: "core", box_url: COREOS_URL_TEMPLATE % ["alpha"]},
+  "coreos-beta"   => {box: "coreos-beta",        bootstrap_os: "coreos", user: "core", box_url: COREOS_URL_TEMPLATE % ["beta"]},
   "ubuntu"        => {box: "bento/ubuntu-16.04", bootstrap_os: "ubuntu", user: "ubuntu"},
 }
 
@@ -24,7 +26,6 @@ $shared_folders = {}
 $forwarded_ports = {}
 $subnet = "172.17.8"
 $os = "ubuntu"
-$box = SUPPORTED_OS[$os][:box]
 # The first three nodes are etcd servers
 $etcd_instances = $num_instances
 # The first two nodes are masters
@@ -39,6 +40,7 @@ if File.exist?(CONFIG)
   require CONFIG
 end
 
+$box = SUPPORTED_OS[$os][:box]
 # if $inventory is not set, try to use example
 $inventory = File.join(File.dirname(__FILE__), "inventory") if ! $inventory
 
@@ -64,8 +66,10 @@ Vagrant.configure("2") do |config|
   # always use Vagrants insecure key
   config.ssh.insert_key = false
   config.vm.box = $box
+  if SUPPORTED_OS[$os].has_key? :box_url
+    config.vm.box_url = SUPPORTED_OS[$os][:box_url]
+  end
   config.ssh.username = SUPPORTED_OS[$os][:user]
-
   # plugin conflict
   if Vagrant.has_plugin?("vagrant-vbguest") then
     config.vbguest.auto_update = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,10 +8,10 @@ Vagrant.require_version ">= 1.8.0"
 CONFIG = File.join(File.dirname(__FILE__), "vagrant/config.rb")
 
 SUPPORTED_OS = {
-  "coreos-stable" => {box: "coreos-stable",      bootstrap_os: "coreos"},
-  "coreos-alpha"  => {box: "coreos-alpha",       bootstrap_os: "coreos"},
-  "coreos-beta"   => {box: "coreos-beta",        bootstrap_os: "coreos"},
-  "ubuntu"        => {box: "bento/ubuntu-16.04", bootstrap_os: "ubuntu"},
+  "coreos-stable" => {box: "coreos-stable",      bootstrap_os: "coreos", user: "core"},
+  "coreos-alpha"  => {box: "coreos-alpha",       bootstrap_os: "coreos", user: "core"},
+  "coreos-beta"   => {box: "coreos-beta",        bootstrap_os: "coreos", user: "core"},
+  "ubuntu"        => {box: "bento/ubuntu-16.04", bootstrap_os: "ubuntu", user: "ubuntu"},
 }
 
 # Defaults for config options defined in CONFIG
@@ -64,6 +64,7 @@ Vagrant.configure("2") do |config|
   # always use Vagrants insecure key
   config.ssh.insert_key = false
   config.vm.box = $box
+  config.ssh.username = SUPPORTED_OS[$os][:user]
 
   # plugin conflict
   if Vagrant.has_plugin?("vagrant-vbguest") then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,13 @@ Vagrant.require_version ">= 1.8.0"
 
 CONFIG = File.join(File.dirname(__FILE__), "vagrant/config.rb")
 
+SUPPORTED_OS = {
+  "coreos-stable" => {box: "coreos-stable",      bootstrap_os: "coreos"},
+  "coreos-alpha"  => {box: "coreos-alpha",       bootstrap_os: "coreos"},
+  "coreos-beta"   => {box: "coreos-beta",        bootstrap_os: "coreos"},
+  "ubuntu"        => {box: "bento/ubuntu-16.04", bootstrap_os: "ubuntu"},
+}
+
 # Defaults for config options defined in CONFIG
 $num_instances = 3
 $instance_name_prefix = "k8s"
@@ -16,7 +23,8 @@ $vm_cpus = 1
 $shared_folders = {}
 $forwarded_ports = {}
 $subnet = "172.17.8"
-$box = "bento/ubuntu-16.04"
+$os = "coreos-stable"
+$box = SUPPORTED_OS[$os][:box]
 # The first three nodes are etcd servers
 $etcd_instances = $num_instances
 # The first two nodes are masters
@@ -103,6 +111,7 @@ Vagrant.configure("2") do |config|
         # Override the default 'calico' with flannel.
         # inventory/group_vars/k8s-cluster.yml
         "kube_network_plugin": "flannel",
+        "bootstrap_os": SUPPORTED_OS[$os][:bootstrap_os]
       }
       config.vm.network :private_network, ip: ip
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ $vm_cpus = 1
 $shared_folders = {}
 $forwarded_ports = {}
 $subnet = "172.17.8"
-$os = "coreos-stable"
+$os = "ubuntu"
 $box = SUPPORTED_OS[$os][:box]
 # The first three nodes are etcd servers
 $etcd_instances = $num_instances

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -39,3 +39,11 @@ k8s-01    Ready     45s
 k8s-02    Ready     45s
 k8s-03    Ready     45s
 ```
+
+Use alternative OS for Vagrant
+==============================
+
+By default, Vagrant uses Ubuntu 16.04 box to provision a local cluster. You may use an alternative supported
+operating system for your local cluster. Change `$os` variable in `Vagrantfile` to another operating system to change
+the vagrant base box. The supported operating systems for vagrant are defined in the `SUPPORTED_OS` constant in
+the `Vagrantfile`.

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -40,10 +40,30 @@ k8s-02    Ready     45s
 k8s-03    Ready     45s
 ```
 
+Customize Vagrant
+=================
+
+You can override the default settings in the `Vagrantfile` either by directly modifying the `Vagrantfile`
+or through an override file.
+
+In the same directory as the `Vagrantfile`, create a folder called `vagrant` and create `config.rb` file in it.
+
+You're able to override the variables defined in `Vagrantfile` by providing the value in the `vagrant/config.rb` file,
+e.g.:
+
+    echo '$forwarded_ports = {8001 => 8001}' >> vagrant/config.rb
+
+and after `vagrant up` or `vagrant reload`, your host will have port forwarding setup with the guest on port 8001.
+
 Use alternative OS for Vagrant
 ==============================
 
 By default, Vagrant uses Ubuntu 16.04 box to provision a local cluster. You may use an alternative supported
-operating system for your local cluster. Change `$os` variable in `Vagrantfile` to another operating system to change
-the vagrant base box. The supported operating systems for vagrant are defined in the `SUPPORTED_OS` constant in
-the `Vagrantfile`.
+operating system for your local cluster.
+
+Customize `$os` variable in `Vagrantfile` or as override, e.g.,:
+
+    echo '$os = "coreos-stable"' >> vagrant/config.rb
+
+
+The supported operating systems for vagrant are defined in the `SUPPORTED_OS` constant in the `Vagrantfile`.


### PR DESCRIPTION
With `coreos-stable`:

```
Friday 02 June 2017  15:07:15 -0400 (0:00:00.051)       0:08:18.893 *********** 
 ____________
< PLAY RECAP >
 ------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

k8s-01                     : ok=368  changed=105  unreachable=0    failed=0   
k8s-02                     : ok=341  changed=99   unreachable=0    failed=0   
k8s-03                     : ok=312  changed=91   unreachable=0    failed=0   

Friday 02 June 2017  15:07:15 -0400 (0:00:00.067)       0:08:18.961 *********** 
=============================================================================== 
download : Download containers if pull is required or told to always pull - 137.63s
bootstrap-os : Bootstrap | Install pip --------------------------------- 13.29s
network_plugin/flannel : Flannel | reload docker.socket ---------------- 10.47s
network_plugin/flannel : Flannel | pause while Docker restarts --------- 10.07s
docker : Docker | pause while Docker restarts -------------------------- 10.04s
download : Download containers if pull is required or told to always pull --- 9.60s
bootstrap-os : Bootstrap | Run bootstrap.sh ----------------------------- 8.26s
kubernetes/master : Master | wait for the apiserver to be running ------- 6.93s
download : Download containers if pull is required or told to always pull --- 6.34s
download : Download containers if pull is required or told to always pull --- 5.86s
download : Download containers if pull is required or told to always pull --- 5.86s
network_plugin/flannel : Flannel | Wait for flannel subnet.env file presence --- 5.64s
bootstrap-os : Install required python modules -------------------------- 3.61s
etcd : wait for etcd up ------------------------------------------------- 3.23s
download : set_fact ----------------------------------------------------- 3.19s
kubernetes/secrets : Gen_certs | update ca-certificates (Debian/Ubuntu/Container Linux by CoreOS) --- 3.12s
download : Download containers if pull is required or told to always pull --- 2.88s
etcd : Gen_certs | update ca-certificates (Debian/Ubuntu/Container Linux by CoreOS) --- 2.80s
download : Download containers if pull is required or told to always pull --- 2.79s
kubernetes/node : nginx-proxy | Write static pod ------------------------ 2.71s
```