### PR TITLE
RBAC certs for kube-proxy/kubelet

### DIFF
--- a/roles/kubernetes/node/tasks/main.yml
+++ b/roles/kubernetes/node/tasks/main.yml
@@ -30,9 +30,12 @@
 
 - name: write the kubecfg (auth) file for kubelet
   template:
-    src: node-kubeconfig.yaml.j2
-    dest: "{{ kube_config_dir }}/node-kubeconfig.yaml"
+    src: "{{ item }}-kubeconfig.yaml.j2"
+    dest: "{{ kube_config_dir }}/{{ item }}-kubeconfig.yaml"
     backup: yes
+  with_items:
+    - node
+    - kube-proxy
   notify: restart kubelet
   tags: kubelet
 

--- a/roles/kubernetes/node/templates/kube-proxy-kubeconfig.yaml.j2
+++ b/roles/kubernetes/node/templates/kube-proxy-kubeconfig.yaml.j2
@@ -8,8 +8,8 @@ clusters:
 users:
 - name: kube-proxy
   user:
-    client-certificate: {{ kube_cert_dir }}/kube-proxy.pem
-    client-key: {{ kube_cert_dir }}/kube-proxy-key.pem
+    client-certificate: {{ kube_cert_dir }}/kube-proxy-{{ inventory_hostname }}.pem
+    client-key: {{ kube_cert_dir }}/kube-proxy-{{ inventory_hostname }}-key.pem
 contexts:
 - context:
     cluster: local

--- a/roles/kubernetes/node/templates/kube-proxy-kubeconfig.yaml.j2
+++ b/roles/kubernetes/node/templates/kube-proxy-kubeconfig.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    certificate-authority: {{ kube_cert_dir }}/ca.pem
+    server: {{ kube_apiserver_endpoint }}
+users:
+- name: kube-proxy
+  user:
+    client-certificate: {{ kube_cert_dir }}/kube-proxy.pem
+    client-key: {{ kube_cert_dir }}/kube-proxy-key.pem
+contexts:
+- context:
+    cluster: local
+    user: kube-proxy
+  name: kube-proxy-{{ cluster_name }}
+current-context: kube-proxy-{{ cluster_name }}

--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -27,7 +27,7 @@ spec:
     - --v={{ kube_log_level }}
     - --master={{ kube_apiserver_endpoint }}
 {% if not is_kube_master %}
-    - --kubeconfig={{kube_config_dir}}/node-kubeconfig.yaml
+    - --kubeconfig={{kube_config_dir}}/kube-proxy-kubeconfig.yaml
 {% endif %}
     - --bind-address={{ ip | default(ansible_default_ipv4.address) }}
     - --cluster-cidr={{ kube_pods_subnet }}
@@ -41,7 +41,7 @@ spec:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host
       readOnly: true
-    - mountPath: {{kube_config_dir}}/node-kubeconfig.yaml
+    - mountPath: {{kube_config_dir}}/kube-proxy-kubeconfig.yaml
       name: "kubeconfig"
       readOnly: true
     - mountPath: {{kube_config_dir}}/ssl
@@ -60,7 +60,7 @@ spec:
 {% endif %}
   - name: "kubeconfig"
     hostPath:
-      path: "{{kube_config_dir}}/node-kubeconfig.yaml"
+      path: "{{kube_config_dir}}/kube-proxy-kubeconfig.yaml"
   - name: "etc-kube-ssl"
     hostPath:
       path: "{{kube_config_dir}}/ssl"

--- a/roles/kubernetes/secrets/files/make-ssl.sh
+++ b/roles/kubernetes/secrets/files/make-ssl.sh
@@ -80,6 +80,7 @@ if [ ! -e "$SSLDIR/ca-key.pem" ]; then
     cat ca.pem >> apiserver.pem
 fi
 
+# Admins
 if [ -n "$MASTERS" ]; then
     for host in $MASTERS; do
         cn="${host%%.*}"
@@ -90,16 +91,22 @@ if [ -n "$MASTERS" ]; then
     done
 fi
 
-# Nodes and Admin
+# Nodes
 if [ -n "$HOSTS" ]; then
     for host in $HOSTS; do
         cn="${host%%.*}"
         # node key
         openssl genrsa -out node-${host}-key.pem 2048 > /dev/null 2>&1
-        openssl req -new -key node-${host}-key.pem -out node-${host}.csr -subj "/CN=kube-node-${cn}" > /dev/null 2>&1
+        openssl req -new -key node-${host}-key.pem -out node-${host}.csr -subj "/CN=kube-node-${cn}/O=system:nodes" > /dev/null 2>&1
         openssl x509 -req -in node-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out node-${host}.pem -days 3650 > /dev/null 2>&1
     done
 fi
+
+# system:kube-proxy
+openssl genrsa -out kube-proxy-key.pem 2048 > /dev/null 2>&1
+openssl req -new -key kube-proxy-key.pem -out kube-proxy.csr -subj "/CN=system:kube-proxy" > /dev/null 2>&1
+openssl x509 -req -in kube-proxy.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out kube-proxy.pem -days 3650 > /dev/null 2>&1
+
 
 # Install certs
 mv *.pem ${SSLDIR}/

--- a/roles/kubernetes/secrets/files/make-ssl.sh
+++ b/roles/kubernetes/secrets/files/make-ssl.sh
@@ -103,9 +103,15 @@ if [ -n "$HOSTS" ]; then
 fi
 
 # system:kube-proxy
-openssl genrsa -out kube-proxy-key.pem 2048 > /dev/null 2>&1
-openssl req -new -key kube-proxy-key.pem -out kube-proxy.csr -subj "/CN=system:kube-proxy" > /dev/null 2>&1
-openssl x509 -req -in kube-proxy.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out kube-proxy.pem -days 3650 > /dev/null 2>&1
+if [ -n "$HOSTS" ]; then
+    for host in $HOSTS; do
+        cn="${host%%.*}"
+        # kube-proxy key
+        openssl genrsa -out kube-proxy-${host}-key.pem 2048 > /dev/null 2>&1
+        openssl req -new -key kube-proxy-${host}-key.pem -out kube-proxy-${host}.csr -subj "/CN=system:kube-proxy" > /dev/null 2>&1
+        openssl x509 -req -in kube-proxy-${host}.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out kube-proxy-${host}.pem -days 3650 > /dev/null 2>&1
+    done
+fi
 
 
 # Install certs

--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -69,17 +69,17 @@
                      'apiserver-key.pem'
                      ]
     all_node_certs: "['ca.pem',
-                    'kube-proxy.pem',
-                    'kube-proxy-key.pem',
                     {% for node in groups['k8s-cluster'] %}
                     'node-{{ node }}.pem',
                     'node-{{ node }}-key.pem',
+                    'kube-proxy-{{ node }}.pem',
+                    'kube-proxy-{{ node }}-key.pem',
                     {% endfor %}]"
     my_node_certs: ['ca.pem',
-                   'kube-proxy.pem',
-                   'kube-proxy-key.pem',
                    'node-{{ inventory_hostname }}.pem',
-                   'node-{{ inventory_hostname }}-key.pem'
+                   'node-{{ inventory_hostname }}-key.pem',
+                   'kube-proxy-{{ inventory_hostname }}.pem',
+                   'kube-proxy-{{ inventory_hostname }}-key.pem',
                    ]
   tags: facts
 

--- a/roles/kubernetes/secrets/tasks/gen_certs_script.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs_script.yml
@@ -69,11 +69,18 @@
                      'apiserver-key.pem'
                      ]
     all_node_certs: "['ca.pem',
+                    'kube-proxy.pem',
+                    'kube-proxy-key.pem',
                     {% for node in groups['k8s-cluster'] %}
                     'node-{{ node }}.pem',
                     'node-{{ node }}-key.pem',
                     {% endfor %}]"
-    my_node_certs: ['ca.pem', 'node-{{ inventory_hostname }}.pem', 'node-{{ inventory_hostname }}-key.pem']
+    my_node_certs: ['ca.pem',
+                   'kube-proxy.pem',
+                   'kube-proxy-key.pem',
+                   'node-{{ inventory_hostname }}.pem',
+                   'node-{{ inventory_hostname }}-key.pem'
+                   ]
   tags: facts
 
 - name: Gen_certs | Gather master certs


### PR DESCRIPTION
1. add kube node cert to **system:nodes** group
2. kube-proxy use its own cert, identified as **system:kube-proxy** user 